### PR TITLE
Fix player serialization

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
@@ -37,7 +37,7 @@ public class InventorySerializer {
      */
     public static JsonObject serializePlayerInventory(PWIPlayer player) {
         JsonObject root = new JsonObject();
-        JsonArray inventory = serializeInventory(player.getInventory());
+        JsonArray inventory = serializeInventory(player.getArmor());
         JsonArray armor = serializeInventory(player.getInventory());
 
         root.add("inventory", inventory);


### PR DESCRIPTION
Minor but important fix to player serialization. Otherwise not only is the wrong data saved, none of the right data is recovered because of deserialization errors. (Index past expected size)