### PR TITLE
Improve Stability

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -114,7 +114,12 @@ public class PerWorldInventory extends JavaPlugin {
     public void onDisable() {
         playerManager.onDisable();
         Printer.disable();
-        DataConverter.disable();
+        try {
+            DataConverter.disable();
+        }
+        catch (NoClassDefFoundError ex) {
+            // To be expected if multiverse isn't loaded
+        }
         getGroupManager().disable();
         getServer().getScheduler().cancelTasks(this);
         instance = null;

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
@@ -73,13 +73,19 @@ public class InventorySerializer {
      */
     public static void setInventory(Player player, JsonObject inv, int format) {
         PlayerInventory inventory = player.getInventory();
-
+        
         ItemStack[] armor = deserializeInventory(inv.getAsJsonArray("armor"), 4, format);
         ItemStack[] inventoryContents = deserializeInventory(inv.getAsJsonArray("inventory"), inventory.getSize(), format);
 
         inventory.clear();
-        inventory.setArmorContents(armor);
-        inventory.setContents(inventoryContents);
+        if (armor != null) {
+        	inventory.setArmorContents(armor);
+        }
+        
+        if (inventoryContents != null) {
+        	inventory.setContents(inventoryContents);
+        }
+       
     }
 
     /**
@@ -91,23 +97,30 @@ public class InventorySerializer {
      * @return An ItemStack array constructed from the given JsonArray
      */
     public static ItemStack[] deserializeInventory(JsonArray inv, int size, int format) {
+    	// Be tolerant if the expected JsonArray tag is missing
+    	if (inv == null) {
+    		return null;
+    	}
+    	
         ItemStack[] contents = new ItemStack[size];
-
         for (int i = 0; i < inv.size(); i++) {
-            JsonObject item = inv.get(i).getAsJsonObject();
-            int index = item.get("index").getAsInt();
-            if (index > size)
-                throw new IllegalArgumentException("Index found is greater than expected size (" + index + " > " + size + ")");
-            if (index > contents.length || index < 0)
-                throw new IllegalArgumentException("Item " + i + " - Slot " + index + " does not exist in this inventory");
-
-            ItemStack is;
-            if (format == 1)
-                is = ItemSerializer.deserializeItem(item);
-            else
-                is = ItemSerializer.getItem(item);
-
-            contents[index] = is;
+        	// We don't want to risk failing to deserialize a players inventory. Try your best
+        	// to deserialize as much as possible.
+        	try {
+	            JsonObject item = inv.get(i).getAsJsonObject();
+	            int index = item.get("index").getAsInt();
+	            
+	            ItemStack is;
+	            if (format == 1)
+	                is = ItemSerializer.deserializeItem(item);
+	            else
+	                is = ItemSerializer.getItem(item);
+	
+	            contents[index] = is;
+        	}
+        	catch (Exception ex) {
+        		ex.printStackTrace();
+        	}
         }
 
         return contents;

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
@@ -38,7 +38,7 @@ public class InventorySerializer {
     public static JsonObject serializePlayerInventory(PWIPlayer player) {
         JsonObject root = new JsonObject();
         JsonArray inventory = serializeInventory(player.getInventory());
-        JsonArray armor = serializeInventory(player.getInventory());
+        JsonArray armor = serializeInventory(player.getArmor());
 
         root.add("inventory", inventory);
         root.add("armor", armor);
@@ -107,7 +107,7 @@ public class InventorySerializer {
             else
                 is = ItemSerializer.getItem(item);
 
-            contents[i] = is;
+            contents[index] = is;
         }
 
         return contents;


### PR DESCRIPTION
Its really undesirable to throw an exception and have a player's entire inventory fail to load. Suddenly they lose everything. Instead this catches some of the more likely error points to greatly reduce what the player might lose. (Even if an individual item fails, others can succeed)

Also bonus fix of using the Index property in deserializeInventory which was otherwise unused.