### PR TITLE
Create Settings mocker and fix game mode change listener tests

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/config/Settings.java
+++ b/src/main/java/me/gnat008/perworldinventory/config/Settings.java
@@ -22,9 +22,12 @@ import org.bukkit.configuration.file.FileConfiguration;
 import java.util.HashMap;
 import java.util.Map;
 
-public class Settings {
+public final class Settings {
 
     private static Map<String, Object> settings = new HashMap<>();
+
+    private Settings() {
+    }
 
     public static void reloadSettings(FileConfiguration config) {
         settings.clear();

--- a/src/test/java/me/gnat008/perworldinventory/config/SettingsMocker.java
+++ b/src/test/java/me/gnat008/perworldinventory/config/SettingsMocker.java
@@ -1,0 +1,46 @@
+package me.gnat008.perworldinventory.config;
+
+import org.bukkit.configuration.file.FileConfiguration;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+/**
+ * Allows mocking of settings for unit tests.
+ */
+public class SettingsMocker {
+
+    private FileConfiguration fileConfiguration;
+    private Set<String> properties;
+
+    private SettingsMocker() {
+        fileConfiguration = mock(FileConfiguration.class);
+        properties = new HashSet<>();
+    }
+
+    /**
+     * Returns a new settings mocker instance.
+     *
+     * @return new instance
+     */
+    public static SettingsMocker create() {
+        return new SettingsMocker();
+    }
+
+    public SettingsMocker set(String key, Object value) {
+        properties.add(key);
+        given(fileConfiguration.get(key)).willReturn(value);
+        return this;
+    }
+
+    /**
+     * Triggers a reload of the settings with the configured properties.
+     */
+    public void save() {
+        given(fileConfiguration.getKeys(true)).willReturn(properties);
+        Settings.reloadSettings(fileConfiguration);
+    }
+}

--- a/src/test/java/me/gnat008/perworldinventory/listeners/PlayerGameModeChangeListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/PlayerGameModeChangeListenerTest.java
@@ -1,9 +1,14 @@
 package me.gnat008.perworldinventory.listeners;
 
-import me.gnat008.perworldinventory.PerWorldInventory;
+import me.gnat008.perworldinventory.config.SettingsMocker;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.player.PlayerGameModeChangeListener;
+import me.gnat008.perworldinventory.permission.PermissionManager;
+import me.gnat008.perworldinventory.permission.PlayerPermission;
+import org.bukkit.GameMode;
+import org.bukkit.World;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.junit.Test;
@@ -12,8 +17,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.Arrays;
+import java.util.List;
+
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 /**
  * Test for {@link PlayerGameModeChangeListener}.
@@ -25,25 +36,60 @@ public class PlayerGameModeChangeListenerTest {
     private PlayerGameModeChangeListener listener;
 
     @Mock
-    PerWorldInventory plugin;
+    private GroupManager groupManager;
 
     @Mock
-    GroupManager groupManager;
+    private PWIPlayerManager playerManager;
 
     @Mock
-    PWIPlayerManager playerManager;
+    private PermissionManager permissionManager;
 
     @Test
     public void shouldBypass() {
         // given
+        World world = mock(World.class);
+        given(world.getName()).willReturn("world");
         Player player = mock(Player.class);
-        PlayerGameModeChangeEvent event = mock(PlayerGameModeChangeEvent.class);
-        given(player.hasPermission("perworldinventory.bypass.gamemode")).willReturn(true);
+        given(player.getWorld()).willReturn(world);
+        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, GameMode.ADVENTURE);
+        Group group = getTestGroup();
+        given(groupManager.getGroupFromWorld("world")).willReturn(group);
+        given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(true);
+        SettingsMocker.create().set("separate-gamemode-inventories", true).save();
 
         // when
         listener.onPlayerGameModeChange(event);
 
         // then
-        verify(playerManager, never()).getPlayerData(null, null, null);
+        verify(playerManager).addPlayer(player, group);
+        verify(playerManager, never()).getPlayerData(any(Group.class), any(GameMode.class), any(Player.class));
+    }
+
+    @Test
+    public void shouldNotBypass() {
+        // given
+        World world = mock(World.class);
+        String worldName = "world";
+        given(world.getName()).willReturn(worldName);
+        Player player = mock(Player.class);
+        given(player.getWorld()).willReturn(world);
+        Group group = getTestGroup();
+        GameMode newGameMode = GameMode.CREATIVE;
+        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
+        given(groupManager.getGroupFromWorld(worldName)).willReturn(group);
+        given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(false);
+        SettingsMocker.create().set("separate-gamemode-inventories", true).save();
+
+        // when
+        listener.onPlayerGameModeChange(event);
+
+        // then
+        verify(playerManager).addPlayer(player, group);
+        verify(playerManager).getPlayerData(group, newGameMode, player);
+    }
+
+    private static Group getTestGroup() {
+        List<String> worlds = Arrays.asList("world", "second-world");
+        return new Group("test-group", worlds, GameMode.SURVIVAL);
     }
 }


### PR DESCRIPTION
- Created SettingsMocker class to mock settings in the static class. Usage:

```java
SettingsMocker.create()
  .set("some-property", true)
  .set("other-config", 33)
  .save();
```

- Fixed existing test for PlayerGameModeChangeListener and the one you sent me via Gitter
   - Used settingsMocker so test is running with the assumed settings
   - Replaced `verify(playerManager, never()).getPlayerData(null, null, null);` with proper `any` matchers: `verify(playerManager, never()).getPlayerData(any(Group.class), ...`, otherwise you're checking that the method was never called with (null, null, null) but other params are fine ;)

I had the idea of the SettingsMocker and so decided to try it out. If you have something else / don't want this, it's fine by me to close without merging.