### PR TITLE
Update to latest Mockito version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -158,7 +158,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-            <version>2.0.5-beta</version>
+            <version>2.2.11</version>
             <exclusions>
                 <exclusion>
                     <artifactId>hamcrest-core</artifactId>

--- a/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
@@ -46,9 +46,9 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.sameInstance;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.argThat;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/me/gnat008/perworldinventory/commands/ConvertCommandTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/commands/ConvertCommandTest.java
@@ -20,7 +20,7 @@ import java.util.List;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/me/gnat008/perworldinventory/commands/ReloadCommandTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/commands/ReloadCommandTest.java
@@ -15,7 +15,7 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/me/gnat008/perworldinventory/commands/SetWorldDefaultsCommandTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/commands/SetWorldDefaultsCommandTest.java
@@ -25,7 +25,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertThat;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.*;
 
 /**

--- a/src/test/java/me/gnat008/perworldinventory/commands/VersionCommandTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/commands/VersionCommandTest.java
@@ -14,7 +14,7 @@ import java.util.Collections;
 
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.argThat;
+import static org.mockito.hamcrest.MockitoHamcrest.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/me/gnat008/perworldinventory/data/FileWriterTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/data/FileWriterTest.java
@@ -28,8 +28,8 @@ import java.util.ArrayList;
 import java.util.UUID;
 
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 
 /**

--- a/src/test/java/me/gnat008/perworldinventory/listeners/PlayerSpawnLocationListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/PlayerSpawnLocationListenerTest.java
@@ -7,6 +7,7 @@ import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.player.PlayerSpawnLocationListener;
 import me.gnat008.perworldinventory.process.InventoryChangeProcess;
+import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.entity.Player;
@@ -17,8 +18,10 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 import org.spigotmc.event.player.PlayerSpawnLocationEvent;
 
+import java.util.Arrays;
+import java.util.Collections;
+
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.only;
 import static org.mockito.Mockito.verify;
@@ -108,6 +111,8 @@ public class PlayerSpawnLocationListenerTest {
         Player player = mock(Player.class);
         World world = mock(World.class);
         given(world.getName()).willReturn("world");
+        Group spawnWorldGroup = new Group("spawn", Arrays.asList("otherWorld", world.getName()), GameMode.SURVIVAL);
+        given(groupManager.getGroupFromWorld(world.getName())).willReturn(spawnWorldGroup);
         Location spawnLocation = new Location(world, 1, 2, 3);
         PlayerSpawnLocationEvent event = new PlayerSpawnLocationEvent(player, spawnLocation);
         given(settings.getProperty(PwiProperties.LOAD_DATA_ON_JOIN)).willReturn(true);
@@ -116,11 +121,13 @@ public class PlayerSpawnLocationListenerTest {
         given(oldWorld.getName()).willReturn("other_world");
         Location lastLocation = new Location(oldWorld, 4, 5, 6);
         given(dataWriter.getLogoutData(player)).willReturn(lastLocation);
+        Group oldWorldGroup = new Group("oldWorldGroup", Collections.singletonList(oldWorld.getName()), GameMode.SURVIVAL);
+        given(groupManager.getGroupFromWorld(oldWorld.getName())).willReturn(oldWorldGroup);
 
         // when
         listener.onPlayerSpawn(event);
 
         // then
-        verify(process, only()).processWorldChangeOnSpawn(any(Player.class), any(Group.class), any(Group.class));
+        verify(process, only()).processWorldChangeOnSpawn(player, oldWorldGroup, spawnWorldGroup);
     }
 }

--- a/src/test/java/me/gnat008/perworldinventory/listeners/entity/EntityPortalEventListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/entity/EntityPortalEventListenerTest.java
@@ -40,10 +40,8 @@ public class EntityPortalEventListenerTest {
         // given
         Pig entity = mock(Pig.class);
         World world = mock(World.class);
-        given(world.getName()).willReturn("test_group");
         Location from = new Location(world, 1, 2, 3);
         World worldNether = mock(World.class);
-        given(world.getName()).willReturn("test_group_nether");
         Location to = new Location(worldNether, 1, 2, 3);
         EntityPortalEvent event = new EntityPortalEvent(entity, from, to, mock(TravelAgent.class));
 

--- a/src/test/java/me/gnat008/perworldinventory/permission/PermissionManagerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/permission/PermissionManagerTest.java
@@ -26,13 +26,13 @@ public class PermissionManagerTest {
     private PermissionManager permissionManager;
 
     @Mock
-    PerWorldInventory plugin;
+    private PerWorldInventory plugin;
 
     @Mock
-    Server server;
+    private Server server;
 
     @Mock
-    PluginManager pluginManager;
+    private PluginManager pluginManager;
 
     @Test
     public void shouldUseDefaultPermissionForCommandSender() {
@@ -62,11 +62,10 @@ public class PermissionManagerTest {
     }
 
     @Test
-    public void shouldDenyToOpSender() {
+    public void shouldDenyToSender() {
         // given
         PermissionNode node = TestPermissions.SYSTEM_LORD;
         CommandSender sender = mock(CommandSender.class);
-        given(sender.isOp()).willReturn(true);
 
         // when
         boolean result = permissionManager.hasPermission(sender, node);
@@ -116,11 +115,10 @@ public class PermissionManagerTest {
     }
 
     @Test
-    public void shouldDenyToOpPlayer() {
+    public void shouldDenyToPlayer() {
         // given
         PermissionNode node = TestPermissions.SYSTEM_LORD;
         Player player = mock(Player.class);
-        given(player.isOp()).willReturn(true);
 
         // when
         boolean result = permissionManager.hasPermission(player, node);

--- a/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
@@ -21,7 +21,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -106,7 +106,6 @@ public class GameModeChangeProcessTest {
         GameMode newGameMode = GameMode.CREATIVE;
         PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
         given(groupManager.getGroupFromWorld(worldName)).willReturn(group);
-        given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(true);
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(true);
 
@@ -121,16 +120,9 @@ public class GameModeChangeProcessTest {
     @Test
     public void shouldDoNothingBecauseDisabled() {
         // given
-        World world = mock(World.class);
-        String worldName = "world";
-        given(world.getName()).willReturn(worldName);
         Player player = mock(Player.class);
-        given(player.getWorld()).willReturn(world);
-        Group group = getTestGroup();
         GameMode newGameMode = GameMode.CREATIVE;
         PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
-        given(groupManager.getGroupFromWorld(worldName)).willReturn(group);
-        given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(false);
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(false);
 
         // when

--- a/src/test/java/me/gnat008/perworldinventory/process/InventoryChangeProcessTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/process/InventoryChangeProcessTest.java
@@ -21,7 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.any;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyZeroInteractions;
@@ -111,7 +111,6 @@ public class InventoryChangeProcessTest {
     public void shouldNotChangeInventoryBecauseSameGroup() {
         // given
         Player player = mock(Player.class);
-        given(player.getGameMode()).willReturn(GameMode.SURVIVAL);
         Group from = mockGroup("test_group", GameMode.SURVIVAL, true);
         Group to = from;
         given(settings.getProperty(PwiProperties.MANAGE_GAMEMODES)).willReturn(false);
@@ -128,7 +127,6 @@ public class InventoryChangeProcessTest {
     public void shouldNotChangeInventoryBecauseBypass() {
         // given
         Player player = mock(Player.class);
-        given(player.getGameMode()).willReturn(GameMode.SURVIVAL);
         Group from = mockGroup("test_group", GameMode.SURVIVAL, true);
         Group to = mockGroup("other_group", GameMode.SURVIVAL, true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(false);
@@ -171,7 +169,6 @@ public class InventoryChangeProcessTest {
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(true);
         given(settings.getProperty(PwiProperties.MANAGE_GAMEMODES)).willReturn(false);
-        given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_WORLDS)).willReturn(true);
 
         // when
         process.processWorldChange(player, from, to);


### PR DESCRIPTION
Sorry to bother you again, I updated Mockito version on various projects already so I want to save you the time of combing through their changelog.

Update from Mockito 2.0.x to 2.2.11
- Changes in imports (org.mockito.Matchers now deprecated -> org.mockito.ArgumentMatchers)
- Different import for argThat in order to work with Hamcrest matchers (org.mockito.hamcrest.MockitoHamcrest)
- Remove mock behaviors that never come into play (Mockito will make the test fail on redundant mock behavior definitions)
- any() no longer matches null value -> add appropriate return values to PlayerSpawnLocationListenerTest