### PR TITLE
Process fix

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/BukkitService.java
+++ b/src/main/java/me/gnat008/perworldinventory/BukkitService.java
@@ -1,7 +1,6 @@
 package me.gnat008.perworldinventory;
 
 import org.bukkit.Bukkit;
-import org.bukkit.scheduler.BukkitRunnable;
 import org.bukkit.scheduler.BukkitTask;
 
 import javax.inject.Inject;
@@ -31,6 +30,17 @@ public class BukkitService {
      */
     public BukkitTask runTask(Runnable task) {
         return Bukkit.getScheduler().runTask(plugin, task);
+    }
+
+    /**
+     * Runs a task after a delay in ticks.
+     *
+     * @param task The task to run.
+     * @param delay The number of ticks before the task is run for the first time.
+     * @return A BukkitTask with the ID number.
+     */
+    public BukkitTask runTaskLater(Runnable task, long delay) {
+        return Bukkit.getScheduler().runTaskLater(plugin, task, delay);
     }
 
     /**

--- a/src/main/java/me/gnat008/perworldinventory/ConsoleLogger.java
+++ b/src/main/java/me/gnat008/perworldinventory/ConsoleLogger.java
@@ -5,20 +5,20 @@ import java.util.logging.Logger;
 /**
  * Static logger for PerWorldInventory.
  */
-public final class PwiLogger {
+public final class ConsoleLogger {
 
     private static Logger logger;
     private static boolean useDebug;
 
-    private PwiLogger() {
+    private ConsoleLogger() {
     }
 
     public static void setLogger(Logger logger) {
-        PwiLogger.logger = logger;
+        ConsoleLogger.logger = logger;
     }
 
     public static void setUseDebug(boolean useDebug) {
-        PwiLogger.useDebug = useDebug;
+        ConsoleLogger.useDebug = useDebug;
     }
 
     public static void severe(String message) {

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -85,7 +85,7 @@ public class PerWorldInventory extends JavaPlugin {
 
     @Override
     public void onEnable() {
-        PwiLogger.setLogger(getLogger());
+        ConsoleLogger.setLogger(getLogger());
 
         // Make the data folders
         if (!(new File(getDataFolder() + File.separator + "data" + File.separator + "defaults").exists())) {
@@ -102,7 +102,7 @@ public class PerWorldInventory extends JavaPlugin {
                 Files.move(source, destination.resolve(source.getFileName()));
             } catch (IOException ex) {
                 if (!(ex instanceof FileAlreadyExistsException)) {
-                    PwiLogger.warning("Unable to move defaults.json to the defaults folder:", ex);
+                    ConsoleLogger.warning("Unable to move defaults.json to the defaults folder:", ex);
                 }
             }
         }
@@ -118,7 +118,7 @@ public class PerWorldInventory extends JavaPlugin {
         injector.provide(DataFolder.class, getDataFolder());
         settings = initSettings();
         injector.register(Settings.class, settings);
-        PwiLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
+        ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
         injectServices(injector);
         registerEventListeners(injector);
 
@@ -185,7 +185,7 @@ public class PerWorldInventory extends JavaPlugin {
             }
         }
 
-        PwiLogger.debug("PerWorldInventory is enabled and debug-mode is active!");
+        ConsoleLogger.debug("PerWorldInventory is enabled and debug-mode is active!");
     }
 
     @Override
@@ -248,7 +248,7 @@ public class PerWorldInventory extends JavaPlugin {
     }
 
     public void reload() {
-        PwiLogger.setUseDebug(settings != null && settings.getProperty(PwiProperties.DEBUG_MODE));
+        ConsoleLogger.setUseDebug(settings != null && settings.getProperty(PwiProperties.DEBUG_MODE));
     }
 
     public Economy getEconomy() {

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -25,7 +25,6 @@ import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.data.DataSourceProvider;
-import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.entity.EntityPortalEventListener;
@@ -59,9 +58,7 @@ import java.util.*;
 public class PerWorldInventory extends JavaPlugin {
 
     private PerWorldInventoryAPI api;
-    private BukkitService bukkitService;
     private Economy economy;
-    private DataSource serializer;
     private GroupManager groupManager;
     private PWIPlayerManager playerManager;
     private Settings settings;
@@ -116,10 +113,9 @@ public class PerWorldInventory extends JavaPlugin {
         injector.register(Server.class, getServer());
         injector.register(PluginManager.class, getServer().getPluginManager());
         injector.provide(DataFolder.class, getDataFolder());
-        settings = initSettings();
-        injector.register(Settings.class, settings);
-        ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
+        injector.registerProvider(DataSource.class, DataSourceProvider.class);
         injectServices(injector);
+        ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
         registerEventListeners(injector);
 
         // Load world groups
@@ -196,10 +192,8 @@ public class PerWorldInventory extends JavaPlugin {
     }
 
     protected void injectServices(Injector injector) {
-        bukkitService = injector.getSingleton(BukkitService.class);
+        settings = injector.getSingleton(Settings.class);
         groupManager = injector.getSingleton(GroupManager.class);
-        serializer = injector.getSingleton(FlatFile.class);
-        injector.registerProvider(DataSource.class, DataSourceProvider.class);
         playerManager = injector.getSingleton(PWIPlayerManager.class);
         permissionManager = injector.getSingleton(PermissionManager.class);
         api = injector.getSingleton(PerWorldInventoryAPI.class);
@@ -305,13 +299,5 @@ public class PerWorldInventory extends JavaPlugin {
         }
 
         return false;
-    }
-
-    private Settings initSettings() {
-        File configFile = new File(getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            saveResource("config.yml", false);
-        }
-        return new Settings(configFile);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -28,10 +28,7 @@ import me.gnat008.perworldinventory.data.FileWriter;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.entity.EntityPortalEventListener;
-import me.gnat008.perworldinventory.listeners.player.PlayerChangedWorldListener;
-import me.gnat008.perworldinventory.listeners.player.PlayerGameModeChangeListener;
-import me.gnat008.perworldinventory.listeners.player.PlayerQuitListener;
-import me.gnat008.perworldinventory.listeners.player.PlayerSpawnLocationListener;
+import me.gnat008.perworldinventory.listeners.player.*;
 import me.gnat008.perworldinventory.listeners.server.PluginListener;
 import me.gnat008.perworldinventory.permission.PermissionManager;
 import me.gnat008.perworldinventory.util.Utils;
@@ -213,6 +210,7 @@ public class PerWorldInventory extends JavaPlugin {
 
         pluginManager.registerEvents(injector.getSingleton(PluginListener.class), this);
 
+        pluginManager.registerEvents(injector.getSingleton(PlayerTeleportListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerChangedWorldListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerGameModeChangeListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerQuitListener.class), this);

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -23,12 +23,14 @@ import me.gnat008.perworldinventory.api.PerWorldInventoryAPI;
 import me.gnat008.perworldinventory.commands.*;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
-import me.gnat008.perworldinventory.data.DataWriter;
-import me.gnat008.perworldinventory.data.FileWriter;
+import me.gnat008.perworldinventory.data.DataSource;
+import me.gnat008.perworldinventory.data.DataSourceProvider;
+import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.entity.EntityPortalEventListener;
 import me.gnat008.perworldinventory.listeners.player.*;
+import me.gnat008.perworldinventory.listeners.server.InventoryLoadingListener;
 import me.gnat008.perworldinventory.listeners.server.PluginListener;
 import me.gnat008.perworldinventory.permission.PermissionManager;
 import me.gnat008.perworldinventory.util.Utils;
@@ -59,7 +61,7 @@ public class PerWorldInventory extends JavaPlugin {
     private PerWorldInventoryAPI api;
     private BukkitService bukkitService;
     private Economy economy;
-    private DataWriter serializer;
+    private DataSource serializer;
     private GroupManager groupManager;
     private PWIPlayerManager playerManager;
     private Settings settings;
@@ -196,8 +198,8 @@ public class PerWorldInventory extends JavaPlugin {
     protected void injectServices(Injector injector) {
         bukkitService = injector.getSingleton(BukkitService.class);
         groupManager = injector.getSingleton(GroupManager.class);
-        serializer = injector.getSingleton(FileWriter.class);
-        injector.register(DataWriter.class, serializer);
+        serializer = injector.getSingleton(FlatFile.class);
+        injector.registerProvider(DataSource.class, DataSourceProvider.class);
         playerManager = injector.getSingleton(PWIPlayerManager.class);
         permissionManager = injector.getSingleton(PermissionManager.class);
         api = injector.getSingleton(PerWorldInventoryAPI.class);
@@ -215,6 +217,7 @@ public class PerWorldInventory extends JavaPlugin {
         pluginManager.registerEvents(injector.getSingleton(PlayerGameModeChangeListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerQuitListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(EntityPortalEventListener.class), this);
+        pluginManager.registerEvents(injector.getSingleton(InventoryLoadingListener.class), this);
 
         // The PlayerSpawnLocationEvent is only fired in Spigot
         // As of version 1.9.2

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -114,6 +114,8 @@ public class PerWorldInventory extends JavaPlugin {
         injector.register(PluginManager.class, getServer().getPluginManager());
         injector.provide(DataFolder.class, getDataFolder());
         injector.registerProvider(DataSource.class, DataSourceProvider.class);
+        settings = initSettings();
+        injector.register(Settings.class, settings);
         injectServices(injector);
         ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
         registerEventListeners(injector);
@@ -299,5 +301,13 @@ public class PerWorldInventory extends JavaPlugin {
         }
 
         return false;
+    }
+
+    private Settings initSettings() {
+        File configFile = new File(getDataFolder(), "config.yml");
+        if (!configFile.exists()) {
+            saveResource("config.yml", false);
+        }
+        return new Settings(configFile);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommand.java
+++ b/src/main/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommand.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.commands;
 
-import me.gnat008.perworldinventory.data.FileWriter;
+import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.permission.AdminPermission;
@@ -15,7 +15,7 @@ import java.util.List;
 public class SetWorldDefaultCommand implements ExecutableCommand {
 
     @Inject
-    private FileWriter fileSerializer;
+    private FlatFile fileSerializer;
     @Inject
     private GroupManager groupManager;
 

--- a/src/main/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommand.java
+++ b/src/main/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommand.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.commands;
 
-import me.gnat008.perworldinventory.data.FlatFile;
+import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.permission.AdminPermission;
@@ -15,10 +15,9 @@ import java.util.List;
 public class SetWorldDefaultCommand implements ExecutableCommand {
 
     @Inject
-    private FlatFile fileSerializer;
+    private DataSource dataSource;
     @Inject
     private GroupManager groupManager;
-
 
     @Override
     public void executeCommand(CommandSender sender, List<String> args) {
@@ -49,7 +48,7 @@ public class SetWorldDefaultCommand implements ExecutableCommand {
         }
 
         if (group != null) {
-            fileSerializer.setGroupDefault(player, group);
+            dataSource.setGroupDefault(player, group);
         }
     }
 

--- a/src/main/java/me/gnat008/perworldinventory/config/PwiProperties.java
+++ b/src/main/java/me/gnat008/perworldinventory/config/PwiProperties.java
@@ -89,6 +89,10 @@ public final class PwiProperties implements SettingsHolder {
     public static final Property<Boolean> LOAD_GAMEMODE =
             newProperty("player.stats.gamemode", false);
 
+    @Comment("Load the maximum health a player can have")
+    public static final Property<Boolean> LOAD_MAX_HEALTH =
+            newProperty("player.stats.max-health", true);
+
     @Comment("Load how much health a player has")
     public static final Property<Boolean> LOAD_HEALTH =
             newProperty("player.stats.health", true);

--- a/src/main/java/me/gnat008/perworldinventory/config/Settings.java
+++ b/src/main/java/me/gnat008/perworldinventory/config/Settings.java
@@ -5,6 +5,9 @@ import ch.jalu.configme.migration.PlainMigrationService;
 import ch.jalu.configme.resource.YamlFileResource;
 
 import java.io.File;
+import java.io.IOException;
+
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
 
 /**
  * Settings class for PWI properties.
@@ -16,9 +19,9 @@ public class Settings extends SettingsManager {
      *
      * @param yamlFile the configuration file to load
      */
-    public Settings(File yamlFile) {
+    public Settings(File yamlFile) throws IOException {
         super(
-            new YamlFileResource(yamlFile),
+            new YamlFileResource(createFileIfNotExists(yamlFile)),
             new PlainMigrationService(),
             PwiProperties.class);
     }

--- a/src/main/java/me/gnat008/perworldinventory/config/Settings.java
+++ b/src/main/java/me/gnat008/perworldinventory/config/Settings.java
@@ -5,9 +5,6 @@ import ch.jalu.configme.migration.PlainMigrationService;
 import ch.jalu.configme.resource.YamlFileResource;
 
 import java.io.File;
-import java.io.IOException;
-
-import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
 
 /**
  * Settings class for PWI properties.
@@ -19,11 +16,11 @@ public class Settings extends SettingsManager {
      *
      * @param yamlFile the configuration file to load
      */
-    public Settings(File yamlFile) throws IOException {
+    public Settings(File yamlFile) {
         super(
-            new YamlFileResource(createFileIfNotExists(yamlFile)),
-            new PlainMigrationService(),
-            PwiProperties.class);
+                new YamlFileResource(yamlFile),
+                new PlainMigrationService(),
+                PwiProperties.class);
     }
 
 }

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSource.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSource.java
@@ -66,4 +66,17 @@ public interface DataSource {
      * @return The location of the player when they last logged out or null
      */
     Location getLogoutData(Player player);
+
+    /**
+     * Set the default inventory loadout for a group. This is the inventory that will
+     * be given to a player the first time they enter a world in the group.
+     * <p>
+     * A snapshot of the player will be taken and saved to a temp file to be deleted after.
+     * This is so some stats are set to max, e.g. health. The snapshot will be restored to
+     * the player after the default loadout has been saved.
+     *
+     * @param player The player performing the command.
+     * @param group The group to write the defaults for.
+     */
+    void setGroupDefault(Player player, Group group);
 }

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSource.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSource.java
@@ -18,12 +18,13 @@
 package me.gnat008.perworldinventory.data;
 
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
 import me.gnat008.perworldinventory.groups.Group;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 
-public interface DataWriter {
+public interface DataSource {
 
     /**
      * Save the location of a player when they log out or are kicked from the server.
@@ -55,7 +56,7 @@ public interface DataWriter {
      * @param gamemode The {@link org.bukkit.GameMode} the player was in
      * @param player The {@link org.bukkit.entity.Player} to set the data to
      */
-    void getFromDatabase(Group group, GameMode gamemode, Player player);
+    void getFromDatabase(Group group, GameMode gamemode, Player player, DeserializeCause cause);
 
     /**
      * Get the name of the world that a player logged out in.

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
@@ -1,0 +1,44 @@
+package me.gnat008.perworldinventory.data;
+
+import ch.jalu.injector.Injector;
+import me.gnat008.perworldinventory.PwiLogger;
+
+import javax.inject.Inject;
+import javax.inject.Provider;
+import java.io.IOException;
+
+/**
+ * Creates the data source
+ */
+public class DataSourceProvider implements Provider<DataSource> {
+
+    @Inject
+    private Injector injector;
+
+    DataSourceProvider() {}
+
+    @Override
+    public DataSource get() {
+        try {
+            return createDataSource();
+        } catch (Exception ex) {
+            PwiLogger.severe("Unable to create data source:", ex);
+            throw new IllegalStateException("Error during initialization of data source", ex);
+        }
+    }
+
+    private DataSource createDataSource() throws ClassNotFoundException, IOException {
+        DataSourceType type = DataSourceType.FLATFILE;
+        DataSource dataSource;
+
+        switch(type) {
+            case FLATFILE:
+                dataSource = injector.getSingleton(FlatFile.class);
+                break;
+            default:
+                throw new UnsupportedOperationException("Unknown data source type '" + type + "'");
+        }
+
+        return dataSource;
+    }
+}

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
@@ -5,7 +5,6 @@ import me.gnat008.perworldinventory.ConsoleLogger;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.io.IOException;
 
 /**
  * Creates the data source
@@ -27,7 +26,7 @@ public class DataSourceProvider implements Provider<DataSource> {
         }
     }
 
-    private DataSource createDataSource() throws ClassNotFoundException, IOException {
+    private DataSource createDataSource() {
         DataSourceType type = DataSourceType.FLATFILE;
         DataSource dataSource;
 

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
@@ -1,7 +1,7 @@
 package me.gnat008.perworldinventory.data;
 
 import ch.jalu.injector.Injector;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
@@ -22,7 +22,7 @@ public class DataSourceProvider implements Provider<DataSource> {
         try {
             return createDataSource();
         } catch (Exception ex) {
-            PwiLogger.severe("Unable to create data source:", ex);
+            ConsoleLogger.severe("Unable to create data source:", ex);
             throw new IllegalStateException("Error during initialization of data source", ex);
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSourceType.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSourceType.java
@@ -1,0 +1,9 @@
+package me.gnat008.perworldinventory.data;
+
+/**
+ * Types of data storage.
+ */
+public enum DataSourceType {
+
+    FLATFILE
+}

--- a/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
@@ -42,6 +42,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.UUID;
 
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
+import static me.gnat008.perworldinventory.util.FileUtils.writeData;
 import static me.gnat008.perworldinventory.util.Utils.zeroPlayer;
 
 public class FlatFile implements DataSource {
@@ -76,11 +78,7 @@ public class FlatFile implements DataSource {
 
     private void saveLogout(File file, PWIPlayer player) {
         try {
-            if (!file.getParentFile().exists())
-                file.getParentFile().mkdir();
-            if (!file.exists())
-                file.createNewFile();
-
+            createFileIfNotExists(file);
             String data = LocationSerializer.serialize(player.getLocation());
             writeData(file, data);
         } catch (IOException ex) {
@@ -94,28 +92,13 @@ public class FlatFile implements DataSource {
         ConsoleLogger.debug("Saving data for player '" + player.getName() + "' in file '" + file.getPath() + "'");
 
         try {
-            if (!file.getParentFile().exists()) {
-                file.getParentFile().mkdir();
-            }
-
-            if (!file.exists()) {
-                file.createNewFile();
-            }
-
+            createFileIfNotExists(file);
             ConsoleLogger.debug("Writing player data for player '" + player.getName() + "' to file");
 
             String data = playerSerializer.serialize(player);
             writeData(file, data);
         } catch (IOException ex) {
             ConsoleLogger.severe("Error creating file '" + file + "':", ex);
-        }
-    }
-
-    public void writeData(final File file, final String data) {
-        try (java.io.FileWriter writer = new java.io.FileWriter(file)) {
-            writer.write(data);
-        } catch (IOException ex) {
-            ConsoleLogger.severe("Could not write data to file '" + file + "':", ex);
         }
     }
 
@@ -246,8 +229,7 @@ public class FlatFile implements DataSource {
 
         File tmp = new File(getUserFolder(player.getUniqueId()), "tmp.json");
         try {
-            tmp.getParentFile().mkdirs();
-            tmp.createNewFile();
+            createFileIfNotExists(tmp);
         } catch (IOException ex) {
             player.sendMessage(ChatColor.DARK_RED + "» " + ChatColor.GRAY +  "Could not create temporary file! Aborting!");
             return;

--- a/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
@@ -23,7 +23,7 @@ import com.google.gson.stream.JsonReader;
 import me.gnat008.perworldinventory.BukkitService;
 import me.gnat008.perworldinventory.DataFolder;
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import me.gnat008.perworldinventory.data.players.PWIPlayerFactory;
 import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
@@ -84,14 +84,14 @@ public class FlatFile implements DataSource {
             String data = LocationSerializer.serialize(player.getLocation());
             writeData(file, data);
         } catch (IOException ex) {
-            PwiLogger.warning("Error creating file '" + file.getPath() + "':", ex);
+            ConsoleLogger.warning("Error creating file '" + file.getPath() + "':", ex);
         }
     }
 
     @Override
     public void saveToDatabase(Group group, GameMode gamemode, PWIPlayer player) {
         File file = getFile(gamemode, group, player.getUuid());
-        PwiLogger.debug("Saving data for player '" + player.getName() + "' in file '" + file.getPath() + "'");
+        ConsoleLogger.debug("Saving data for player '" + player.getName() + "' in file '" + file.getPath() + "'");
 
         try {
             if (!file.getParentFile().exists()) {
@@ -102,12 +102,12 @@ public class FlatFile implements DataSource {
                 file.createNewFile();
             }
 
-            PwiLogger.debug("Writing player data for player '" + player.getName() + "' to file");
+            ConsoleLogger.debug("Writing player data for player '" + player.getName() + "' to file");
 
             String data = playerSerializer.serialize(player);
             writeData(file, data);
         } catch (IOException ex) {
-            PwiLogger.severe("Error creating file '" + file + "':", ex);
+            ConsoleLogger.severe("Error creating file '" + file + "':", ex);
         }
     }
 
@@ -115,7 +115,7 @@ public class FlatFile implements DataSource {
         try (java.io.FileWriter writer = new java.io.FileWriter(file)) {
             writer.write(data);
         } catch (IOException ex) {
-            PwiLogger.severe("Could not write data to file '" + file + "':", ex);
+            ConsoleLogger.severe("Could not write data to file '" + file + "':", ex);
         }
     }
 
@@ -123,7 +123,7 @@ public class FlatFile implements DataSource {
     public void getFromDatabase(Group group, GameMode gamemode, Player player, DeserializeCause cause) {
         File file = getFile(gamemode, group, player.getUniqueId());
 
-        PwiLogger.debug("Getting data for player '" + player.getName() + "' from file '" + file.getPath() + "'");
+        ConsoleLogger.debug("Getting data for player '" + player.getName() + "' from file '" + file.getPath() + "'");
 
         bukkitService.runTaskAsync(() -> {
             try (JsonReader reader = new JsonReader(new FileReader(file))) {
@@ -136,11 +136,11 @@ public class FlatFile implements DataSource {
                     file.getParentFile().mkdir();
                 }
 
-                PwiLogger.debug("File not found for player '" + player.getName() + "' for group '" + group.getName() + "'. Getting data from default sources");
+                ConsoleLogger.debug("File not found for player '" + player.getName() + "' for group '" + group.getName() + "'. Getting data from default sources");
 
                 getFromDefaults(group, player, cause);
             } catch (IOException exIO) {
-                PwiLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
+                ConsoleLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
                         "' in gamemode '" + gamemode.toString() + "' for reason:", exIO);
             }
         });
@@ -161,7 +161,7 @@ public class FlatFile implements DataSource {
             location = null;
         } catch (IOException ioEx) {
             // Something went wrong
-            PwiLogger.warning("Unable to get logout location data for '" + player.getName() + "':", ioEx);
+            ConsoleLogger.warning("Unable to get logout location data for '" + player.getName() + "':", ioEx);
             location = null;
         }
 
@@ -186,14 +186,14 @@ public class FlatFile implements DataSource {
             } catch (FileNotFoundException ex2) {
                 player.sendMessage(ChatColor.RED + "» " + ChatColor.GRAY + "Something went horribly wrong when loading your inventory! " +
                         "Please notify a server administrator!");
-                PwiLogger.severe("Unable to find inventory data for player '" + player.getName() +
+                ConsoleLogger.severe("Unable to find inventory data for player '" + player.getName() +
                         "' for group '" + group.getName() + "':", ex2);
             } catch (IOException exIO) {
-                PwiLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
+                ConsoleLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
                         "' for reason:", exIO);
             }
         } catch (IOException exIO) {
-            PwiLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
+            ConsoleLogger.severe("Unable to read data for '" + player.getName() + "' for group '" + group.getName() +
                     "' for reason:", exIO);
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
@@ -236,17 +236,7 @@ public class FlatFile implements DataSource {
         return new File(FILE_PATH, uuid.toString());
     }
 
-    /**
-     * Set the default inventory loadout for a group. This is the inventory that will
-     * be given to a player the first time they enter a world in the group.
-     * <p>
-     * A snapshot of the player will be taken and saved to a temp file to be deleted after.
-     * This is so some stats are set to max, e.g. health. The snapshot will be restored to
-     * the player after the default loadout has been saved.
-     *
-     * @param player The player performing the command.
-     * @param group The group to write the defaults for.
-     */
+    @Override
     public void setGroupDefault(Player player, Group group) {
         File file = new File(plugin.getDefaultFilesDirectory(), group.getName() + ".json");
         if (!file.exists()) {

--- a/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
@@ -29,7 +29,7 @@ import com.onarandombox.multiverseinventories.api.profile.WorldGroupProfile;
 import com.onarandombox.multiverseinventories.api.share.Sharables;
 import me.gnat008.perworldinventory.BukkitService;
 import me.gnat008.perworldinventory.PwiLogger;
-import me.gnat008.perworldinventory.data.FileWriter;
+import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.serializers.InventorySerializer;
 import me.gnat008.perworldinventory.data.serializers.PotionEffectSerializer;
 import me.gnat008.perworldinventory.groups.Group;
@@ -51,7 +51,7 @@ public class DataConverter {
     @Inject
     private BukkitService bukkitService;
     @Inject
-    private FileWriter serializer;
+    private FlatFile serializer;
     @Inject
     private GroupManager groupManager;
     @Inject

--- a/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
@@ -45,6 +45,9 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.*;
 
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
+import static me.gnat008.perworldinventory.util.FileUtils.writeData;
+
 @NoMethodScan
 public class DataConverter {
 
@@ -88,11 +91,8 @@ public class DataConverter {
                                 String data = serializeMVIToNewFormat(playerData);
 
                                 File file = serializer.getFile(gameMode, groupManager.getGroup(mvgroup.getName()), player1.getUniqueId());
-                                if (!file.getParentFile().exists())
-                                    file.getParentFile().mkdir();
-                                if (!file.exists())
-                                    file.createNewFile();
-                                serializer.writeData(file, data);
+                                createFileIfNotExists(file);
+                                writeData(file, data);
                             }
                         } catch (Exception ex) {
                             ConsoleLogger.warning("Error importing inventory for player: " + player1.getName() +

--- a/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
@@ -28,7 +28,7 @@ import com.onarandombox.multiverseinventories.api.profile.ProfileType;
 import com.onarandombox.multiverseinventories.api.profile.WorldGroupProfile;
 import com.onarandombox.multiverseinventories.api.share.Sharables;
 import me.gnat008.perworldinventory.BukkitService;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.serializers.InventorySerializer;
 import me.gnat008.perworldinventory.data.serializers.PotionEffectSerializer;
@@ -62,7 +62,7 @@ public class DataConverter {
     DataConverter() {}
 
     public void convertMultiVerseData() {
-        PwiLogger.info("Beginning data conversion. This may take a while...");
+        ConsoleLogger.info("Beginning data conversion. This may take a while...");
         MultiverseInventories mvinventories = (MultiverseInventories) pluginManager.getPlugin("Multiverse-Inventories");
         List<WorldGroupProfile> mvgroups = mvinventories.getGroupManager().getGroups();
 
@@ -95,7 +95,7 @@ public class DataConverter {
                                 serializer.writeData(file, data);
                             }
                         } catch (Exception ex) {
-                            PwiLogger.warning("Error importing inventory for player: " + player1.getName() +
+                            ConsoleLogger.warning("Error importing inventory for player: " + player1.getName() +
                                     " For group: " + mvgroup.getName() + " For gamemode: " + gameMode.name(), ex);
                         }
                     });
@@ -104,13 +104,13 @@ public class DataConverter {
         }
 
         groupManager.saveGroupsToDisk();
-        PwiLogger.info("Data conversion complete! Disabling Multiverse-Inventories...");
+        ConsoleLogger.info("Data conversion complete! Disabling Multiverse-Inventories...");
         pluginManager.disablePlugin(mvinventories);
-        PwiLogger.info("Multiverse-Inventories disabled! Don't forget to remove the .jar!");
+        ConsoleLogger.info("Multiverse-Inventories disabled! Don't forget to remove the .jar!");
     }
 
     public void convertMultiInvData() {
-        PwiLogger.info("Beginning data conversion. This may take awhile...");
+        ConsoleLogger.info("Beginning data conversion. This may take awhile...");
         MultiInv multiinv = (MultiInv) pluginManager.getPlugin("MultiInv");
         /*MultiInvAPI mvAPI = new MultiInvAPI(multiinv);
 
@@ -132,9 +132,9 @@ public class DataConverter {
         }*/
 
         groupManager.saveGroupsToDisk();
-        PwiLogger.info("Data conversion complete! Disabling MultiInv...");
+        ConsoleLogger.info("Data conversion complete! Disabling MultiInv...");
         pluginManager.disablePlugin(multiinv);
-        PwiLogger.info("MultiInv disabled! Don't forget to remove the .jar!");
+        ConsoleLogger.info("MultiInv disabled! Don't forget to remove the .jar!");
     }
 
     private String serializeMVIToNewFormat(PlayerProfile data) {

--- a/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayer.java
@@ -20,6 +20,7 @@ package me.gnat008.perworldinventory.data.players;
 import me.gnat008.perworldinventory.groups.Group;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
@@ -49,6 +50,7 @@ public class PWIPlayer {
     private float experience;
     private boolean isFlying;
     private int foodLevel;
+    private double maxHealth;
     private double health;
     private GameMode gamemode;
     private int level;
@@ -89,6 +91,7 @@ public class PWIPlayer {
         this.experience = player.getExp();
         this.isFlying = player.isFlying();
         this.foodLevel = player.getFoodLevel();
+        this.maxHealth = player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getBaseValue();
         this.health = player.getHealth();
         this.gamemode = player.getGameMode();
         this.level = player.getLevel();
@@ -263,6 +266,24 @@ public class PWIPlayer {
      */
     public void setFoodLevel(int foodLevel) {
         this.foodLevel = foodLevel;
+    }
+
+    /**
+     * Get a player's maximum health.
+     *
+     * @return Maximum health
+     */
+    public double getMaxHealth() {
+        return maxHealth;
+    }
+
+    /**
+     * Set a player's maximum health.
+     *
+     * @param maxHealth Maximum health
+     */
+    public void setMaxHealth(double maxHealth) {
+        this.maxHealth = maxHealth;
     }
 
     /**

--- a/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayerManager.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayerManager.java
@@ -157,6 +157,7 @@ public class PWIPlayerManager {
      * @param group The Group the player is in
      * @param gamemode The Gamemode the player is in
      * @param player The Player to get the data for
+     * @param cause The the trigger for getting player data
      */
     public void getPlayerData(Group group, GameMode gamemode, Player player, DeserializeCause cause) {
         PwiLogger.debug("Trying to get data from cache for player '" + player.getName() + "'");
@@ -175,6 +176,7 @@ public class PWIPlayerManager {
      *
      * @param group The Group the player is currently in.
      * @param player The player to save.
+     * @param createTask If a new task should be started.
      */
     public void savePlayer(Group group, Player player, boolean createTask) {
         String key = makeKey(player.getUniqueId(), group, player.getGameMode());
@@ -223,6 +225,7 @@ public class PWIPlayerManager {
      * Return whether a player in a given group is currently cached.
      *
      * @param group The group the player was in.
+     * @param gameMode The GameMode the player is in.
      * @param player The player to check for.
      *
      * @return True if a {@link PWIPlayer} is cached.
@@ -321,6 +324,7 @@ public class PWIPlayerManager {
      *
      * @param group The Group to grab data from
      * @param gameMode The GameMode to get the data for
+     * @param uuid The UUID of the player
      * @return The PWIPlayer
      */
     private PWIPlayer getCachedPlayer(Group group, GameMode gameMode, UUID uuid) {
@@ -402,6 +406,18 @@ public class PWIPlayerManager {
         }
     }
 
+    /**
+     * Create a key to get and save a player's data in the cache.
+     * <p>
+     *     The format of a key is as follows:
+     *     <i>uuid.group-name.gamemode</i>
+     * </p>
+     *
+     * @param uuid The UUID of the player.
+     * @param group The Group the player is in.
+     * @param gameMode The player's current GameMode.
+     * @return The key.
+     */
     public String makeKey(UUID uuid, Group group, GameMode gameMode) {
         String key = uuid.toString() + "." + group.getName() + ".";
         if (settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES))

--- a/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayerManager.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/players/PWIPlayerManager.java
@@ -19,7 +19,7 @@ package me.gnat008.perworldinventory.data.players;
 
 import me.gnat008.perworldinventory.BukkitService;
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
@@ -109,10 +109,10 @@ public class PWIPlayerManager {
     public String addPlayer(Player player, Group group) {
         String key = makeKey(player.getUniqueId(), group, player.getGameMode());
 
-        PwiLogger.debug("Adding player '" + player.getName() + "' to cache; key is '" + key + "'");
+        ConsoleLogger.debug("Adding player '" + player.getName() + "' to cache; key is '" + key + "'");
 
         if (playerCache.containsKey(key)) {
-            PwiLogger.debug("Player '" + player.getName() + "' found in cache! Updating cache");
+            ConsoleLogger.debug("Player '" + player.getName() + "' found in cache! Updating cache");
             updateCache(player, playerCache.get(key));
         } else {
             playerCache.put(key, pwiPlayerFactory.create(player, group));
@@ -160,13 +160,13 @@ public class PWIPlayerManager {
      * @param cause The the trigger for getting player data
      */
     public void getPlayerData(Group group, GameMode gamemode, Player player, DeserializeCause cause) {
-        PwiLogger.debug("Trying to get data from cache for player '" + player.getName() + "'");
+        ConsoleLogger.debug("Trying to get data from cache for player '" + player.getName() + "'");
         zeroPlayer(plugin, player);
 
         if(isPlayerCached(group, gamemode, player)) {
             getDataFromCache(group, gamemode, player, cause);
         } else {
-            PwiLogger.debug("Player was not in cache! Loading from file");
+            ConsoleLogger.debug("Player was not in cache! Loading from file");
             dataSource.getFromDatabase(group, gamemode, player, cause);
         }
     }
@@ -196,7 +196,7 @@ public class PWIPlayerManager {
                 Group groupKey = groupManager.getGroup(parts[1]);
                 GameMode gamemode = GameMode.valueOf(parts[2].toUpperCase());
 
-                PwiLogger.debug("Saving cached player '" + cached.getName() + "' for group '" + groupKey.getName() + "' with gamemdde '" + gamemode.name() + "'");
+                ConsoleLogger.debug("Saving cached player '" + cached.getName() + "' for group '" + groupKey.getName() + "' with gamemdde '" + gamemode.name() + "'");
 
                 cached.setSaved(true);
                 if (!createTask) {
@@ -239,12 +239,12 @@ public class PWIPlayerManager {
     private void getDataFromCache(Group group, GameMode gamemode, Player player, DeserializeCause cause) {
         PWIPlayer cachedPlayer = getCachedPlayer(group, gamemode, player.getUniqueId());
         if (cachedPlayer == null) {
-            PwiLogger.debug("No data for player '" + player.getName() + "' found in cache");
+            ConsoleLogger.debug("No data for player '" + player.getName() + "' found in cache");
 
             return;
         }
 
-        PwiLogger.debug("Player '" + player.getName() + "' found in cache! Setting their data");
+        ConsoleLogger.debug("Player '" + player.getName() + "' found in cache! Setting their data");
 
         if (settings.getProperty(PwiProperties.LOAD_ENDER_CHESTS))
             player.getEnderChest().setContents(cachedPlayer.getEnderChest());
@@ -293,7 +293,7 @@ public class PWIPlayerManager {
         if (settings.getProperty(PwiProperties.USE_ECONOMY)) {
             Economy econ = plugin.getEconomy();
             if (econ == null) {
-                PwiLogger.warning("Economy saving is turned on, but no economy found!");
+                ConsoleLogger.warning("Economy saving is turned on, but no economy found!");
                 return;
             }
 
@@ -301,14 +301,14 @@ public class PWIPlayerManager {
             if (er.transactionSuccess()) {
                 econ.depositPlayer(player, cachedPlayer.getBalance());
             } else {
-                PwiLogger.warning("[ECON] Unable to withdraw currency from '" + player.getName() + "': " + er.errorMessage);
+                ConsoleLogger.warning("[ECON] Unable to withdraw currency from '" + player.getName() + "': " + er.errorMessage);
             }
 
             EconomyResponse bankER = econ.bankWithdraw(player.getName(), econ.bankBalance(player.getName()).amount);
             if (bankER.transactionSuccess()) {
                 econ.bankDeposit(player.getName(), cachedPlayer.getBankBalance());
             } else {
-                PwiLogger.warning("[ECON] Unable to withdraw currency from bank of '" + player.getName() + "': " + er.errorMessage);
+                ConsoleLogger.warning("[ECON] Unable to withdraw currency from bank of '" + player.getName() + "': " + er.errorMessage);
             }
         }
 
@@ -330,7 +330,7 @@ public class PWIPlayerManager {
     private PWIPlayer getCachedPlayer(Group group, GameMode gameMode, UUID uuid) {
         String key = makeKey(uuid, group, gameMode);
 
-        PwiLogger.debug("Looking for cached data with key '" + key + "'");
+        ConsoleLogger.debug("Looking for cached data with key '" + key + "'");
 
         return playerCache.get(key);
     }
@@ -354,15 +354,15 @@ public class PWIPlayerManager {
                     Group group = groupManager.getGroup(parts[1]);
                     GameMode gamemode = GameMode.valueOf(parts[2].toUpperCase());
 
-                    PwiLogger.debug("Saving cached player with key '" + key + "'");
-                    PwiLogger.debug("Player: " + player.getName());
-                    PwiLogger.debug("Group: " + group.getName());
-                    PwiLogger.debug("Gamemode: " + gamemode.toString());
+                    ConsoleLogger.debug("Saving cached player with key '" + key + "'");
+                    ConsoleLogger.debug("Player: " + player.getName());
+                    ConsoleLogger.debug("Group: " + group.getName());
+                    ConsoleLogger.debug("Gamemode: " + gamemode.toString());
 
                     player.setSaved(true);
                     bukkitService.runTaskAsync(() -> dataSource.saveToDatabase(group, gamemode, player));
                 } else {
-                    PwiLogger.debug("Removing player '" + player.getName() + "' from cache");
+                    ConsoleLogger.debug("Removing player '" + player.getName() + "' from cache");
                     playerCache.remove(key);
                 }
             }
@@ -376,7 +376,7 @@ public class PWIPlayerManager {
      * @param currentPlayer The PWIPlayer currently in the cache
      */
     public void updateCache(Player newData, PWIPlayer currentPlayer) {
-        PwiLogger.debug("Updating player '" + newData.getName() + "' in the cache");
+        ConsoleLogger.debug("Updating player '" + newData.getName() + "' in the cache");
 
         currentPlayer.setSaved(false);
 

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/DeserializeCause.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/DeserializeCause.java
@@ -1,0 +1,11 @@
+package me.gnat008.perworldinventory.data.serializers;
+
+/**
+ *
+ */
+public enum DeserializeCause {
+
+    WORLD_CHANGE,
+    GAMEMODE_CHANGE,
+    CHANGED_DEFAULTS
+}

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/EconomySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/EconomySerializer.java
@@ -30,21 +30,12 @@ public class EconomySerializer {
     public static JsonObject serialize(PWIPlayer player, Economy econ) {
         JsonObject data = new JsonObject();
 
-        if (econ.bankBalance(player.getName()).transactionSuccess()) {
-            data.addProperty("bank-balance", player.getBankBalance());
-        }
-
         data.addProperty("balance", player.getBalance());
 
         return data;
     }
 
     public static void deserialize(Economy econ, JsonObject data, Player player) {
-        if (data.has("bank-balance")) {
-            ConsoleLogger.debug("[ECON] Depositing " + data.get("bank-balance").getAsDouble() + " to bank of '" + player.getName() + "'!");
-            econ.bankDeposit(player.getName(), data.get("bank-balance").getAsDouble());
-        }
-
         if (data.has("balance")) {
             ConsoleLogger.debug("[ECON] Depositing " + data.get("balance").getAsDouble() + " to '" + player.getName() + "'!");
             econ.depositPlayer(player, data.get("balance").getAsDouble());

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/EconomySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/EconomySerializer.java
@@ -18,7 +18,7 @@
 package me.gnat008.perworldinventory.data.serializers;
 
 import com.google.gson.JsonObject;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import net.milkbowl.vault.economy.Economy;
 import org.bukkit.entity.Player;
@@ -41,12 +41,12 @@ public class EconomySerializer {
 
     public static void deserialize(Economy econ, JsonObject data, Player player) {
         if (data.has("bank-balance")) {
-            PwiLogger.debug("[ECON] Depositing " + data.get("bank-balance").getAsDouble() + " to bank of '" + player.getName() + "'!");
+            ConsoleLogger.debug("[ECON] Depositing " + data.get("bank-balance").getAsDouble() + " to bank of '" + player.getName() + "'!");
             econ.bankDeposit(player.getName(), data.get("bank-balance").getAsDouble());
         }
 
         if (data.has("balance")) {
-            PwiLogger.debug("[ECON] Depositing " + data.get("balance").getAsDouble() + " to '" + player.getName() + "'!");
+            ConsoleLogger.debug("[ECON] Depositing " + data.get("balance").getAsDouble() + " to '" + player.getName() + "'!");
             econ.depositPlayer(player, data.get("balance").getAsDouble());
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/InventorySerializer.java
@@ -19,7 +19,7 @@ package me.gnat008.perworldinventory.data.serializers;
 
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -120,7 +120,7 @@ public class InventorySerializer {
 	            contents[index] = is;
         	}
         	catch (Exception ex) {
-                PwiLogger.warning("Failed to deserialize inventory:", ex);
+                ConsoleLogger.warning("Failed to deserialize inventory:", ex);
         	}
         }
 

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/ItemSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/ItemSerializer.java
@@ -20,7 +20,7 @@ package me.gnat008.perworldinventory.data.serializers;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import org.bukkit.Material;
 import org.bukkit.enchantments.Enchantment;
@@ -83,7 +83,7 @@ public class ItemSerializer {
 
             values.addProperty("item", encoded);
         } catch (IOException ex) {
-            PwiLogger.severe("Unable to serialize item '" + item.getType().toString() + "':", ex);
+            ConsoleLogger.severe("Unable to serialize item '" + item.getType().toString() + "':", ex);
             return null;
         }
 
@@ -107,7 +107,7 @@ public class ItemSerializer {
                      BukkitObjectInputStream dataInput = new BukkitObjectInputStream(inputStream)) {
                     return (ItemStack) dataInput.readObject();
                 } catch (IOException | ClassNotFoundException ex) {
-                    PwiLogger.severe("Unable to deserialize an item:", ex);
+                    ConsoleLogger.severe("Unable to deserialize an item:", ex);
                     return new ItemStack(Material.AIR);
                 }
             default:

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
@@ -20,7 +20,7 @@ package me.gnat008.perworldinventory.data.serializers;
 import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
@@ -63,7 +63,7 @@ public class PlayerSerializer {
         Gson gson = new Gson();
         JsonObject root = new JsonObject();
 
-        PwiLogger.debug("[SERIALIZER] Serializing player '" + player.getName()+ "'");
+        ConsoleLogger.debug("[SERIALIZER] Serializing player '" + player.getName()+ "'");
         root.addProperty("data-format", 2);
         root.add("ender-chest", inventorySerializer.serializeInventory(player.getEnderChest()));
         root.add("inventory", inventorySerializer.serializePlayerInventory(player));
@@ -72,7 +72,7 @@ public class PlayerSerializer {
         if (plugin.isEconEnabled())
             root.add("economy", EconomySerializer.serialize(player, plugin.getEconomy()));
 
-        PwiLogger.debug("[SERIALIZER] Done serializing player '" + player.getName()+ "'");
+        ConsoleLogger.debug("[SERIALIZER] Done serializing player '" + player.getName()+ "'");
 
         return gson.toJson(root);
     }
@@ -85,7 +85,7 @@ public class PlayerSerializer {
      * @param player The Player to apply the deserialized information to.
      */
     public void deserialize(final JsonObject data, final Player player, DeserializeCause cause) {
-        PwiLogger.debug("[SERIALIZER] Deserializing player '" + player.getName()+ "'");
+        ConsoleLogger.debug("[SERIALIZER] Deserializing player '" + player.getName()+ "'");
 
         int format = 0;
         if (data.has("data-format"))
@@ -101,20 +101,20 @@ public class PlayerSerializer {
         if (plugin.isEconEnabled()) {
             Economy econ = plugin.getEconomy();
             if (econ == null) {
-                PwiLogger.warning("Economy saving is turned on, but no economy found!");
+                ConsoleLogger.warning("Economy saving is turned on, but no economy found!");
                 return;
             }
 
-            PwiLogger.debug("[ECON] Withdrawing " + econ.getBalance(player) + " from '" + player.getName() + "'!");
+            ConsoleLogger.debug("[ECON] Withdrawing " + econ.getBalance(player) + " from '" + player.getName() + "'!");
             EconomyResponse er = econ.withdrawPlayer(player, econ.getBalance(player));
             if (!er.transactionSuccess()) {
-                PwiLogger.warning("[ECON] Unable to withdraw funds from '" + player.getName() + "': " + er.errorMessage);
+                ConsoleLogger.warning("[ECON] Unable to withdraw funds from '" + player.getName() + "': " + er.errorMessage);
             }
 
-            PwiLogger.debug("[ECON] Withdrawing " + econ.bankBalance(player.getName()) + " from bank of '" + player.getName() + "'!");
+            ConsoleLogger.debug("[ECON] Withdrawing " + econ.bankBalance(player.getName()) + " from bank of '" + player.getName() + "'!");
             EconomyResponse bankER = econ.bankWithdraw(player.getName(), econ.bankBalance(player.getName()).amount);
             if (!bankER.transactionSuccess()) {
-                PwiLogger.warning("[ECON] Unable to withdraw bank funds from '" + player.getName() + "': " + er.errorMessage);
+                ConsoleLogger.warning("[ECON] Unable to withdraw bank funds from '" + player.getName() + "': " + er.errorMessage);
             }
 
             if (data.has("economy") && er.transactionSuccess() && bankER.transactionSuccess()) {
@@ -122,7 +122,7 @@ public class PlayerSerializer {
             }
         }
 
-        PwiLogger.debug("[SERIALIZER] Done deserializing player '" + player.getName()+ "'");
+        ConsoleLogger.debug("[SERIALIZER] Done deserializing player '" + player.getName()+ "'");
 
         // Call event to signal loading is done
         InventoryLoadCompleteEvent event = new InventoryLoadCompleteEvent(player, cause);

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
@@ -111,13 +111,7 @@ public class PlayerSerializer {
                 ConsoleLogger.warning("[ECON] Unable to withdraw funds from '" + player.getName() + "': " + er.errorMessage);
             }
 
-            ConsoleLogger.debug("[ECON] Withdrawing " + econ.bankBalance(player.getName()) + " from bank of '" + player.getName() + "'!");
-            EconomyResponse bankER = econ.bankWithdraw(player.getName(), econ.bankBalance(player.getName()).amount);
-            if (!bankER.transactionSuccess()) {
-                ConsoleLogger.warning("[ECON] Unable to withdraw bank funds from '" + player.getName() + "': " + er.errorMessage);
-            }
-
-            if (data.has("economy") && er.transactionSuccess() && bankER.transactionSuccess()) {
+            if (data.has("economy") && er.transactionSuccess()) {
                 EconomySerializer.deserialize(econ, data.getAsJsonObject("economy"), player);
             }
         }

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/PlayerSerializer.java
@@ -24,8 +24,10 @@ import me.gnat008.perworldinventory.PwiLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
+import me.gnat008.perworldinventory.events.InventoryLoadCompleteEvent;
 import net.milkbowl.vault.economy.Economy;
 import net.milkbowl.vault.economy.EconomyResponse;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 
 import javax.inject.Inject;
@@ -61,6 +63,7 @@ public class PlayerSerializer {
         Gson gson = new Gson();
         JsonObject root = new JsonObject();
 
+        PwiLogger.debug("[SERIALIZER] Serializing player '" + player.getName()+ "'");
         root.addProperty("data-format", 2);
         root.add("ender-chest", inventorySerializer.serializeInventory(player.getEnderChest()));
         root.add("inventory", inventorySerializer.serializePlayerInventory(player));
@@ -68,6 +71,8 @@ public class PlayerSerializer {
 
         if (plugin.isEconEnabled())
             root.add("economy", EconomySerializer.serialize(player, plugin.getEconomy()));
+
+        PwiLogger.debug("[SERIALIZER] Done serializing player '" + player.getName()+ "'");
 
         return gson.toJson(root);
     }
@@ -79,7 +84,9 @@ public class PlayerSerializer {
      * @param data   The saved player information.
      * @param player The Player to apply the deserialized information to.
      */
-    public void deserialize(final JsonObject data, final Player player) {
+    public void deserialize(final JsonObject data, final Player player, DeserializeCause cause) {
+        PwiLogger.debug("[SERIALIZER] Deserializing player '" + player.getName()+ "'");
+
         int format = 0;
         if (data.has("data-format"))
             format = data.get("data-format").getAsInt();
@@ -114,5 +121,11 @@ public class PlayerSerializer {
                 EconomySerializer.deserialize(econ, data.getAsJsonObject("economy"), player);
             }
         }
+
+        PwiLogger.debug("[SERIALIZER] Done deserializing player '" + player.getName()+ "'");
+
+        // Call event to signal loading is done
+        InventoryLoadCompleteEvent event = new InventoryLoadCompleteEvent(player, cause);
+        Bukkit.getPluginManager().callEvent(event);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
@@ -22,6 +22,7 @@ import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import org.bukkit.GameMode;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.Player;
 
 import javax.inject.Inject;
@@ -49,6 +50,7 @@ public class StatSerializer {
         root.addProperty("flying", player.isFlying());
         root.addProperty("food", player.getFoodLevel());
         root.addProperty("gamemode", player.getGamemode().toString());
+        root.addProperty("max-health", player.getMaxHealth());
         root.addProperty("health", player.getHealth());
         root.addProperty("level", player.getLevel());
         root.add("potion-effects", PotionEffectSerializer.serialize(player.getPotionEffects()));
@@ -81,14 +83,16 @@ public class StatSerializer {
             player.setFlying(stats.get("flying").getAsBoolean());
         if (settings.getProperty(PwiProperties.LOAD_HUNGER) && stats.has("food"))
             player.setFoodLevel(stats.get("food").getAsInt());
+        if (settings.getProperty(PwiProperties.LOAD_MAX_HEALTH) && stats.has("max-health"))
+            player.getAttribute(Attribute.GENERIC_MAX_HEALTH).setBaseValue(stats.get("max-health").getAsDouble());
         if (settings.getProperty(PwiProperties.LOAD_HEALTH) && stats.has("health")) {
             double health = stats.get("health").getAsDouble();
-            if (health <= player.getMaxHealth()) {
+            if (health <= player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()) {
                 player.setHealth(health);
             } else if (health <= 0) {
-                player.setHealth(player.getMaxHealth());
+                player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
             } else {
-                player.setHealth(player.getMaxHealth());
+                player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
             }
         }
         if (settings.getProperty(PwiProperties.LOAD_GAMEMODE) && (!settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)) && stats.has("gamemode")) {

--- a/src/main/java/me/gnat008/perworldinventory/events/InventoryLoadCompleteEvent.java
+++ b/src/main/java/me/gnat008/perworldinventory/events/InventoryLoadCompleteEvent.java
@@ -1,0 +1,50 @@
+package me.gnat008.perworldinventory.events;
+
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+/**
+ * Event to be called when a player's inventory and stats are fully
+ * loaded and set to the player.
+ */
+public class InventoryLoadCompleteEvent extends Event {
+
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private Player player;
+    private DeserializeCause cause;
+
+    public InventoryLoadCompleteEvent(Player player, DeserializeCause cause) {
+        this.player = player;
+        this.cause = cause;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * Get the player in this event.
+     *
+     * @return The player.
+     */
+    public Player getPlayer() {
+        return player;
+    }
+
+    /**
+     * Get the {@link DeserializeCause} of this event.
+     *
+     * @return The cause of the event.
+     */
+    public DeserializeCause getCause() {
+        return cause;
+    }
+}

--- a/src/main/java/me/gnat008/perworldinventory/groups/GroupManager.java
+++ b/src/main/java/me/gnat008/perworldinventory/groups/GroupManager.java
@@ -18,7 +18,7 @@
 package me.gnat008.perworldinventory.groups;
 
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.util.FileUtils;
@@ -73,7 +73,7 @@ public class GroupManager {
      * @param gamemode The default GameMode for this group.
      */
     public void addGroup(String name, Collection<String> worlds, GameMode gamemode) {
-        PwiLogger.debug("Adding group to memory. Group: " + name + " Worlds: " + worlds.toString() + " Gamemode: " + gamemode.name());
+        ConsoleLogger.debug("Adding group to memory. Group: " + name + " Worlds: " + worlds.toString() + " Gamemode: " + gamemode.name());
 
         Set<String> worldSet = new HashSet<>();
         worldSet.addAll(worlds);
@@ -175,7 +175,7 @@ public class GroupManager {
         try {
             groupsConfigFile.save(plugin.getDataFolder() + "/worlds.yml");
         } catch (IOException ex) {
-            PwiLogger.warning("Could not save the groups config to disk:", ex);
+            ConsoleLogger.warning("Could not save the groups config to disk:", ex);
         }
     }
 
@@ -186,7 +186,7 @@ public class GroupManager {
             try {
                 FileUtils.copyFile(fileFrom, fileTo);
             } catch (IOException ex) {
-                PwiLogger.severe("An error occurred copying file '" + fileFrom.getName() + "' to '" + fileTo.getName() + "':", ex);
+                ConsoleLogger.severe("An error occurred copying file '" + fileFrom.getName() + "' to '" + fileTo.getName() + "':", ex);
             }
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/listeners/entity/EntityPortalEventListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/entity/EntityPortalEventListener.java
@@ -1,9 +1,8 @@
 package me.gnat008.perworldinventory.listeners.entity;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
-import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Item;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -29,13 +28,13 @@ public class EntityPortalEventListener implements Listener {
         if (!(event.getEntity() instanceof Item))
             return;
 
-        PwiLogger.debug("[ENTITYPORTALEVENT] A '" + event.getEntity().getName() + "' is going through a portal!");
+        ConsoleLogger.debug("[ENTITYPORTALEVENT] A '" + event.getEntity().getName() + "' is going through a portal!");
 
         String worldFrom = event.getFrom().getWorld().getName();
 
         // For some reason, event.getTo().getWorld().getName() is sometimes null
         if (event.getTo() == null || event.getTo().getWorld() == null) { // Not gonna bother checking name; its already a WTF that this is needed
-            PwiLogger.debug("[ENTITYPORTALEVENT] event.getTo().getWorld().getName() would throw a NPE! Exiting method!");
+            ConsoleLogger.debug("[ENTITYPORTALEVENT] event.getTo().getWorld().getName() would throw a NPE! Exiting method!");
             return;
         }
 
@@ -45,7 +44,7 @@ public class EntityPortalEventListener implements Listener {
 
         // If the groups are different, cancel the event
         if (!from.equals(to)) {
-            PwiLogger.debug("[ENTITYPORTALEVENT] Group '" + from.getName() + "' and group '" + to.getName() + "' are different! Canceling event!");
+            ConsoleLogger.debug("[ENTITYPORTALEVENT] Group '" + from.getName() + "' and group '" + to.getName() + "' are different! Canceling event!");
             event.setCancelled(true);
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListener.java
@@ -17,7 +17,13 @@
 
 package me.gnat008.perworldinventory.listeners.player;
 
+import me.gnat008.perworldinventory.BukkitService;
+import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.process.GameModeChangeProcess;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -27,15 +33,33 @@ import javax.inject.Inject;
 
 public class PlayerGameModeChangeListener implements Listener {
 
+    private BukkitService bukkitService;
     private GameModeChangeProcess process;
+    private GroupManager groupManager;
+    private PWIPlayerManager playerManager;
 
     @Inject
-    PlayerGameModeChangeListener(GameModeChangeProcess process) {
+    PlayerGameModeChangeListener(BukkitService bukkitService, GameModeChangeProcess process,
+                                 GroupManager groupManager, PWIPlayerManager playerManager) {
+        this.bukkitService = bukkitService;
         this.process = process;
+        this.groupManager = groupManager;
+        this.playerManager = playerManager;
     }
 
     @EventHandler(priority = EventPriority.MONITOR)
     public void onPlayerGameModeChange(PlayerGameModeChangeEvent event) {
-        process.processGameModeChange(event);
+        if (event.isCancelled()) {
+            return;
+        }
+
+        Player player = event.getPlayer();
+        Group group = groupManager.getGroupFromWorld(player.getWorld().getName());
+
+        PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' changed to GameMode '" +
+                event.getNewGameMode().name() + "' in group '" + group.getName() + "'");
+
+        playerManager.addPlayer(player, group);
+        bukkitService.runTaskLater(() -> process.processGameModeChange(player, event.getNewGameMode(), group), 1L);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListener.java
@@ -18,7 +18,7 @@
 package me.gnat008.perworldinventory.listeners.player;
 
 import me.gnat008.perworldinventory.BukkitService;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
@@ -56,7 +56,7 @@ public class PlayerGameModeChangeListener implements Listener {
         Player player = event.getPlayer();
         Group group = groupManager.getGroupFromWorld(player.getWorld().getName());
 
-        PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' changed to GameMode '" +
+        ConsoleLogger.debug("[GM PROCESS] Player '" + player.getName() + "' changed to GameMode '" +
                 event.getNewGameMode().name() + "' in group '" + group.getName() + "'");
 
         playerManager.addPlayer(player, group);

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListener.java
@@ -17,7 +17,7 @@
 
 package me.gnat008.perworldinventory.listeners.player;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
@@ -57,11 +57,11 @@ public class PlayerSpawnLocationListener implements Listener {
         Player player = event.getPlayer();
         String spawnWorld = event.getSpawnLocation().getWorld().getName();
 
-        PwiLogger.debug("Player '" + player.getName() + "' joining! Spawning in world '" + spawnWorld + "'. Getting last logout location");
+        ConsoleLogger.debug("Player '" + player.getName() + "' joining! Spawning in world '" + spawnWorld + "'. Getting last logout location");
 
         Location lastLogout = dataSource.getLogoutData(player);
         if (lastLogout != null) {
-            PwiLogger.debug("Logout location found for player '" + player.getName() + "'!");
+            ConsoleLogger.debug("Logout location found for player '" + player.getName() + "'!");
 
             if (!lastLogout.getWorld().getName().equals(spawnWorld)) {
                 Group spawnGroup = groupManager.getGroupFromWorld(spawnWorld);

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListener.java
@@ -20,7 +20,7 @@ package me.gnat008.perworldinventory.listeners.player;
 import me.gnat008.perworldinventory.PwiLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
-import me.gnat008.perworldinventory.data.DataWriter;
+import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.process.InventoryChangeProcess;
@@ -35,15 +35,15 @@ import javax.inject.Inject;
 
 public class PlayerSpawnLocationListener implements Listener {
 
-    private DataWriter dataWriter;
+    private DataSource dataSource;
     private GroupManager groupManager;
     private InventoryChangeProcess process;
     private Settings settings;
 
     @Inject
-    PlayerSpawnLocationListener(DataWriter dataWriter, GroupManager groupManager, InventoryChangeProcess process,
+    PlayerSpawnLocationListener(DataSource dataSource, GroupManager groupManager, InventoryChangeProcess process,
                                 Settings settings) {
-        this.dataWriter = dataWriter;
+        this.dataSource = dataSource;
         this.groupManager = groupManager;
         this.process = process;
         this.settings = settings;
@@ -59,7 +59,7 @@ public class PlayerSpawnLocationListener implements Listener {
 
         PwiLogger.debug("Player '" + player.getName() + "' joining! Spawning in world '" + spawnWorld + "'. Getting last logout location");
 
-        Location lastLogout = dataWriter.getLogoutData(player);
+        Location lastLogout = dataSource.getLogoutData(player);
         if (lastLogout != null) {
             PwiLogger.debug("Logout location found for player '" + player.getName() + "'!");
 

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListener.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.listeners.player;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
@@ -39,7 +39,7 @@ public class PlayerTeleportListener implements Listener {
             return;
         }
 
-        PwiLogger.debug("[EVENTS] Player '" + event.getPlayer().getName() + "' going from world '" + from + "' to world '" + to + "'");
+        ConsoleLogger.debug("[EVENTS] Player '" + event.getPlayer().getName() + "' going from world '" + from + "' to world '" + to + "'");
 
         Group groupFrom = groupManager.getGroupFromWorld(from.getWorld().getName());
         Group groupTo = groupManager.getGroupFromWorld(to.getWorld().getName());

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListener.java
@@ -1,0 +1,53 @@
+package me.gnat008.perworldinventory.listeners.player;
+
+import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
+import org.bukkit.Location;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import javax.inject.Inject;
+
+/**
+ * Listens for {@link PlayerTeleportEvent} and adds players to the cache.
+ */
+public class PlayerTeleportListener implements Listener {
+
+    private GroupManager groupManager;
+    private PWIPlayerManager playerManager;
+
+    @Inject
+    PlayerTeleportListener(GroupManager groupManager, PWIPlayerManager playerManager) {
+        this.groupManager = groupManager;
+        this.playerManager = playerManager;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerTeleport(PlayerTeleportEvent event) {
+        if (event.isCancelled()) {
+            return;
+        }
+
+        Location from = event.getFrom();
+        Location to = event.getTo();
+
+        if (from.getWorld().equals(to.getWorld())) {
+            return;
+        }
+
+        PwiLogger.debug("[EVENTS] Player '" + event.getPlayer().getName() + "' going from world '" + from + "' to world '" + to + "'");
+
+        Group groupFrom = groupManager.getGroupFromWorld(from.getWorld().getName());
+        Group groupTo = groupManager.getGroupFromWorld(to.getWorld().getName());
+
+        if (groupFrom.equals(groupTo)) {
+            return;
+        }
+
+        playerManager.addPlayer(event.getPlayer(), groupFrom);
+    }
+}

--- a/src/main/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListener.java
@@ -1,0 +1,30 @@
+package me.gnat008.perworldinventory.listeners.server;
+
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
+import me.gnat008.perworldinventory.events.InventoryLoadCompleteEvent;
+import me.gnat008.perworldinventory.process.InventoryChangeProcess;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+
+import javax.inject.Inject;
+
+/**
+ * Class for listening for inventory loading events.
+ */
+public class InventoryLoadingListener implements Listener {
+
+    private InventoryChangeProcess process;
+
+    @Inject
+    InventoryLoadingListener(InventoryChangeProcess process) {
+        this.process = process;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onLoadComplete(InventoryLoadCompleteEvent event) {
+        if (event.getCause() == DeserializeCause.WORLD_CHANGE) {
+            process.postProcessWorldChange(event.getPlayer());
+        }
+    }
+}

--- a/src/main/java/me/gnat008/perworldinventory/permission/PermissionManager.java
+++ b/src/main/java/me/gnat008/perworldinventory/permission/PermissionManager.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.permission;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
@@ -63,7 +63,7 @@ public class PermissionManager {
 
                 this.usingPermissionsPlugin = true;
             } catch (Exception ex) {
-                PwiLogger.warning("Error encountered while checking for permission plugin:", ex);
+                ConsoleLogger.warning("Error encountered while checking for permission plugin:", ex);
             }
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
@@ -4,20 +4,16 @@ import me.gnat008.perworldinventory.PwiLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
 import me.gnat008.perworldinventory.groups.Group;
-import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.permission.PermissionManager;
 import me.gnat008.perworldinventory.permission.PlayerPermission;
 import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
 
 import javax.inject.Inject;
 
 public class GameModeChangeProcess {
-
-    @Inject
-    private GroupManager groupManager;
 
     @Inject
     private PermissionManager permissionManager;
@@ -34,30 +30,24 @@ public class GameModeChangeProcess {
     /**
      * Process a player's GameMode changing.
      *
-     * @param event The {@link PlayerGameModeChangeEvent} that is happening.
+     * @param player The player who's GameMode is changing.
+     * @param newGameMode The player's new GameMode.
+     * @param group The {@link Group} the player is in.
      */
-    public void processGameModeChange(PlayerGameModeChangeEvent event) {
+    public void processGameModeChange(Player player, GameMode newGameMode, Group group) {
         if (!settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)) {
             return;
         }
 
-        Player player = event.getPlayer();
-        GameMode newGameMode = event.getNewGameMode();
-        Group group = groupManager.getGroupFromWorld(player.getWorld().getName());
-
-        PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' changed to GameMode '" + newGameMode.name() + "' in group '" + group.getName() + "'");
-
-        playerManager.addPlayer(player, group);
-
         if (settings.getProperty(PwiProperties.DISABLE_BYPASS)) {
             PwiLogger.debug("[GM PROCESS] Bypass system is disabled in the config, loading data");
 
-            playerManager.getPlayerData(group, newGameMode, player);
+            playerManager.getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
         } else {
             if (!permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)) {
                 PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' does not have GameMode bypass permission! Loading data");
 
-                playerManager.getPlayerData(group, newGameMode, player);
+                playerManager.getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
             } else {
                 PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' has GameMode bypass permission!");
             }

--- a/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.process;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
@@ -40,16 +40,16 @@ public class GameModeChangeProcess {
         }
 
         if (settings.getProperty(PwiProperties.DISABLE_BYPASS)) {
-            PwiLogger.debug("[GM PROCESS] Bypass system is disabled in the config, loading data");
+            ConsoleLogger.debug("[GM PROCESS] Bypass system is disabled in the config, loading data");
 
             playerManager.getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
         } else {
             if (!permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)) {
-                PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' does not have GameMode bypass permission! Loading data");
+                ConsoleLogger.debug("[GM PROCESS] Player '" + player.getName() + "' does not have GameMode bypass permission! Loading data");
 
                 playerManager.getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
             } else {
-                PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' has GameMode bypass permission!");
+                ConsoleLogger.debug("[GM PROCESS] Player '" + player.getName() + "' has GameMode bypass permission!");
             }
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/GameModeChangeProcess.java
@@ -45,21 +45,21 @@ public class GameModeChangeProcess {
         GameMode newGameMode = event.getNewGameMode();
         Group group = groupManager.getGroupFromWorld(player.getWorld().getName());
 
-        PwiLogger.debug("Player '" + player.getName() + "' changed to gamemode '" + newGameMode.name() + "' in group '" + group.getName() + "'");
+        PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' changed to GameMode '" + newGameMode.name() + "' in group '" + group.getName() + "'");
 
         playerManager.addPlayer(player, group);
 
         if (settings.getProperty(PwiProperties.DISABLE_BYPASS)) {
-            PwiLogger.debug("Bypass system is disabled in the config, loading data");
+            PwiLogger.debug("[GM PROCESS] Bypass system is disabled in the config, loading data");
 
             playerManager.getPlayerData(group, newGameMode, player);
         } else {
             if (!permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)) {
-                PwiLogger.debug("Player '" + player.getName() + "' does not have gamemode bypass permission! Loading data");
+                PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' does not have GameMode bypass permission! Loading data");
 
                 playerManager.getPlayerData(group, newGameMode, player);
             } else {
-                PwiLogger.debug("Player '" + player.getName() + "' has gamemode bypass permission!");
+                PwiLogger.debug("[GM PROCESS] Player '" + player.getName() + "' has GameMode bypass permission!");
             }
         }
     }

--- a/src/main/java/me/gnat008/perworldinventory/process/InventoryChangeProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/InventoryChangeProcess.java
@@ -46,10 +46,6 @@ public class InventoryChangeProcess {
         Group groupFrom = groupManager.getGroupFromWorld(worldFrom);
         Group groupTo = groupManager.getGroupFromWorld(worldTo);
 
-        PwiLogger.debug("Player '" + player.getName() + "' going from world '" + worldFrom + "' to world '" + worldTo + "'");
-
-        playerManager.addPlayer(player, groupFrom);
-
         processWorldChange(player, groupFrom, groupTo);
     }
 
@@ -63,7 +59,7 @@ public class InventoryChangeProcess {
      */
     public void processWorldChangeOnSpawn(Player player, Group from, Group to) {
         if (!from.equals(to)) {
-            PwiLogger.debug("Logout world groups are different! Saving data for player '" + player.getName() + "' for group '" + from.getName() + "'");
+            PwiLogger.debug("[PROCESS] Logout world groups are different! Saving data for player '" + player.getName() + "' for group '" + from.getName() + "'");
 
             playerManager.addPlayer(player, from);
 
@@ -80,40 +76,40 @@ public class InventoryChangeProcess {
      * @param to The group they're going to.
      */
     protected void processWorldChange(Player player, Group from, Group to) {
-        // Check of the FROM group is configured
+        // Check if the FROM group is configured
         if (!from.isConfigured() && settings.getProperty(PwiProperties.SHARE_IF_UNCONFIGURED)) {
-            PwiLogger.debug("FROM group (" + from.getName() + ") is not defined, and plugin configured to share inventory");
+            PwiLogger.debug("[PROCESS] FROM group (" + from.getName() + ") is not defined, and plugin configured to share inventory");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check if the groups are actually the same group
         if (from.equals(to)) {
-            PwiLogger.debug("Both groups are the same: '" + to.getName() + "'");
+            PwiLogger.debug("[PROCESS] Both groups are the same: '" + to.getName() + "'");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check of the TO group is configured
         if (!to.isConfigured() && settings.getProperty(PwiProperties.SHARE_IF_UNCONFIGURED)) {
-            PwiLogger.debug("TO group (" + to.getName() + ") is not defined, and plugin configured to share inventory");
+            PwiLogger.debug("[PROCESS] TO group (" + to.getName() + ") is not defined, and plugin configured to share inventory");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check if the player bypasses the changes
         if (!settings.getProperty(PwiProperties.DISABLE_BYPASS) && permissionManager.hasPermission(player, PlayerPermission.BYPASS_WORLDS)) {
-            PwiLogger.debug("Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_WORLDS.getNode() + "' permission! Returning");
+            PwiLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_WORLDS.getNode() + "' permission! Returning");
             postProcessWorldChange(player, to);
             return;
         }
 
-        // Check if gamemodes have separate inventories
+        // Check if GameModes have separate inventories
         if (settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)) {
-            PwiLogger.debug("Gamemodes are separated! Loading data for player '" + player.getName() + "' for group '" + to.getName() + "' in gamemode '" + player.getGameMode().name() + "'");
+            PwiLogger.debug("[PROCESS] GameModes are separated! Loading data for player '" + player.getName() + "' for group '" + to.getName() + "' in gamemode '" + player.getGameMode().name() + "'");
             playerManager.getPlayerData(to, player.getGameMode(), player);
         } else {
-            PwiLogger.debug("Loading data for player '" + player.getName() + "' for group '" + to.getName() + "'");
+            PwiLogger.debug("[PROCESS] Loading data for player '" + player.getName() + "' for group '" + to.getName() + "'");
             playerManager.getPlayerData(to, GameMode.SURVIVAL, player);
         }
 
@@ -131,9 +127,9 @@ public class InventoryChangeProcess {
         // Check if we should manage the player's gamemode when changing worlds
         if (settings.getProperty(PwiProperties.MANAGE_GAMEMODES)) {
             if (permissionManager.hasPermission(player, PlayerPermission.BYPASS_ENFORCEGAMEMODE)) {
-                PwiLogger.debug("Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_ENFORCEGAMEMODE.getNode() + "' permission! Not enforcing gamemode.");
+                PwiLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_ENFORCEGAMEMODE.getNode() + "' permission! Not enforcing gamemode.");
             } else {
-                PwiLogger.debug("PWI manages gamemodes! Setting player '" + player.getName() + "' to gamemode " + to.getGameMode().name());
+                PwiLogger.debug("[PROCESS] PWI manages GameModes! Setting player '" + player.getName() + "' to gamemode " + to.getGameMode().name());
                 player.setGameMode(to.getGameMode());
             }
         }

--- a/src/main/java/me/gnat008/perworldinventory/process/InventoryChangeProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/InventoryChangeProcess.java
@@ -1,7 +1,7 @@
 package me.gnat008.perworldinventory.process;
 
 import me.gnat008.perworldinventory.BukkitService;
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
@@ -64,7 +64,7 @@ public class InventoryChangeProcess {
      */
     public void processWorldChangeOnSpawn(Player player, Group from, Group to) {
         if (!from.equals(to)) {
-            PwiLogger.debug("[PROCESS] Logout world groups are different! Saving data for player '" + player.getName() + "' for group '" + from.getName() + "'");
+            ConsoleLogger.debug("[PROCESS] Logout world groups are different! Saving data for player '" + player.getName() + "' for group '" + from.getName() + "'");
 
             playerManager.addPlayer(player, from);
 
@@ -83,37 +83,37 @@ public class InventoryChangeProcess {
     protected void processWorldChange(Player player, Group from, Group to) {
         // Check if the FROM group is configured
         if (!from.isConfigured() && settings.getProperty(PwiProperties.SHARE_IF_UNCONFIGURED)) {
-            PwiLogger.debug("[PROCESS] FROM group (" + from.getName() + ") is not defined, and plugin configured to share inventory");
+            ConsoleLogger.debug("[PROCESS] FROM group (" + from.getName() + ") is not defined, and plugin configured to share inventory");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check if the groups are actually the same group
         if (from.equals(to)) {
-            PwiLogger.debug("[PROCESS] Both groups are the same: '" + to.getName() + "'");
+            ConsoleLogger.debug("[PROCESS] Both groups are the same: '" + to.getName() + "'");
             return;
         }
 
         // Check of the TO group is configured
         if (!to.isConfigured() && settings.getProperty(PwiProperties.SHARE_IF_UNCONFIGURED)) {
-            PwiLogger.debug("[PROCESS] TO group (" + to.getName() + ") is not defined, and plugin configured to share inventory");
+            ConsoleLogger.debug("[PROCESS] TO group (" + to.getName() + ") is not defined, and plugin configured to share inventory");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check if the player bypasses the changes
         if (!settings.getProperty(PwiProperties.DISABLE_BYPASS) && permissionManager.hasPermission(player, PlayerPermission.BYPASS_WORLDS)) {
-            PwiLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_WORLDS.getNode() + "' permission! Returning");
+            ConsoleLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_WORLDS.getNode() + "' permission! Returning");
             postProcessWorldChange(player, to);
             return;
         }
 
         // Check if GameModes have separate inventories
         if (settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)) {
-            PwiLogger.debug("[PROCESS] GameModes are separated! Loading data for player '" + player.getName() + "' for group '" + to.getName() + "' in gamemode '" + player.getGameMode().name() + "'");
+            ConsoleLogger.debug("[PROCESS] GameModes are separated! Loading data for player '" + player.getName() + "' for group '" + to.getName() + "' in gamemode '" + player.getGameMode().name() + "'");
             playerManager.getPlayerData(to, player.getGameMode(), player, DeserializeCause.WORLD_CHANGE);
         } else {
-            PwiLogger.debug("[PROCESS] Loading data for player '" + player.getName() + "' for group '" + to.getName() + "'");
+            ConsoleLogger.debug("[PROCESS] Loading data for player '" + player.getName() + "' for group '" + to.getName() + "'");
             playerManager.getPlayerData(to, GameMode.SURVIVAL, player, DeserializeCause.WORLD_CHANGE);
         }
     }
@@ -133,9 +133,9 @@ public class InventoryChangeProcess {
         // Check if we should manage the player's gamemode when changing worlds
         if (settings.getProperty(PwiProperties.MANAGE_GAMEMODES)) {
             if (permissionManager.hasPermission(player, PlayerPermission.BYPASS_ENFORCEGAMEMODE)) {
-                PwiLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_ENFORCEGAMEMODE.getNode() + "' permission! Not enforcing gamemode.");
+                ConsoleLogger.debug("[PROCESS] Player '" + player.getName() + "' has '" + PlayerPermission.BYPASS_ENFORCEGAMEMODE.getNode() + "' permission! Not enforcing gamemode.");
             } else {
-                PwiLogger.debug("[PROCESS] PWI manages GameModes! Setting player '" + player.getName() +
+                ConsoleLogger.debug("[PROCESS] PWI manages GameModes! Setting player '" + player.getName() +
                         "' to gamemode " + group.getGameMode().name());
 
                 bukkitService.runTaskLater(() -> player.setGameMode(group.getGameMode()), 1L);

--- a/src/main/java/me/gnat008/perworldinventory/process/PlayerQuitProcess.java
+++ b/src/main/java/me/gnat008/perworldinventory/process/PlayerQuitProcess.java
@@ -1,6 +1,6 @@
 package me.gnat008.perworldinventory.process;
 
-import me.gnat008.perworldinventory.PwiLogger;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.Group;
@@ -32,17 +32,17 @@ public class PlayerQuitProcess {
         String logoutWorld = player.getWorld().getName();
         Group group = groupManager.getGroupFromWorld(logoutWorld);
 
-        PwiLogger.debug("Player '" + player.getName() + "' quit! Checking cache");
+        ConsoleLogger.debug("Player '" + player.getName() + "' quit! Checking cache");
 
         PWIPlayer cached = playerManager.getPlayer(group, player);
         if (cached != null) {
-            PwiLogger.debug("Cached data for player '" + player.getName() + "' found! Updating and setting them as saved");
+            ConsoleLogger.debug("Cached data for player '" + player.getName() + "' found! Updating and setting them as saved");
 
             playerManager.updateCache(player, cached);
             cached.setSaved(true);
         }
 
-        PwiLogger.debug("Saving logout data for player '" + player.getName() + "'...");
+        ConsoleLogger.debug("Saving logout data for player '" + player.getName() + "'...");
         playerManager.savePlayer(group, player, true);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/util/FileUtils.java
+++ b/src/main/java/me/gnat008/perworldinventory/util/FileUtils.java
@@ -1,11 +1,16 @@
 package me.gnat008.perworldinventory.util;
 
+import me.gnat008.perworldinventory.ConsoleLogger;
+
 import java.io.*;
 
 /**
  * Utility methods for handling files.
  */
-public class FileUtils {
+public final class FileUtils {
+
+    private FileUtils() {
+    }
 
     /**
      * Copy a file from one location to another. The file will not be deleted.
@@ -23,5 +28,43 @@ public class FileUtils {
                 out.write(buff, 0, len);
             }
         }
+    }
+
+    /**
+     * Writes the given data to the provided file.
+     *
+     * @param file The file to write to.
+     * @param data The data to write.
+     */
+    public static void writeData(File file, String data) {
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(data);
+        } catch (IOException ex) {
+            ConsoleLogger.severe("Could not write data to file '" + file + "':", ex);
+        }
+    }
+
+    /**
+     * Creates the given file if it doesn't exist.
+     *
+     * @param file The file to create if necessary.
+     * @return The given file (allows inline use).
+     * @throws IOException if file could not be created
+     */
+    public static File createFileIfNotExists(File file) throws IOException {
+        if (!file.exists()) {
+            if (!file.getParentFile().exists()) {
+                boolean success = file.getParentFile().mkdirs();
+                if (!success) {
+                    ConsoleLogger.warning("Could not create parent directories while trying to create '" + file + "'");
+                }
+            }
+
+            boolean success = file.createNewFile();
+            if (!success) {
+                ConsoleLogger.warning("Could not create file '" + file + "'");
+            }
+        }
+        return file;
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/util/Utils.java
+++ b/src/main/java/me/gnat008/perworldinventory/util/Utils.java
@@ -1,6 +1,10 @@
 package me.gnat008.perworldinventory.util;
 
-import java.io.*;
+import me.gnat008.perworldinventory.PerWorldInventory;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.Player;
+import org.bukkit.potion.PotionEffect;
 
 /**
  * Class that holds utility methods.
@@ -41,4 +45,44 @@ public final class Utils {
         return false;
     }
 
+    /**
+     * Clear a player's inventory and set all of their stats to default.
+     *
+     * @param plugin {@link PerWorldInventory} for econ.
+     * @param player The player to zero.
+     */
+    public static void zeroPlayer(PerWorldInventory plugin, Player player) {
+        zeroPlayer(plugin, player, true);
+    }
+
+    /**
+     * Set a player's stats to defaults, and optionally clear their inventory.
+     *
+     * @param plugin {@link PerWorldInventory} for econ.
+     * @param player The player to zero.
+     * @param clearInventory Clear the player's inventory.
+     */
+    public static void zeroPlayer(PerWorldInventory plugin, Player player, boolean clearInventory) {
+        if (clearInventory) {
+            player.getInventory().clear();
+            player.getEnderChest().clear();
+        }
+
+        player.setExp(0.0F);
+        player.setFoodLevel(20);
+        player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+        player.setLevel(0);
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            player.removePotionEffect(effect.getType());
+        }
+        player.setSaturation(20.0F);
+        player.setFallDistance(0.0f);
+        player.setFireTicks(0);
+
+        if (plugin.isEconEnabled()) {
+            Economy econ = plugin.getEconomy();
+            econ.bankWithdraw(player.getName(), econ.bankBalance(player.getName()).amount);
+            econ.withdrawPlayer(player, econ.getBalance(player));
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -47,6 +47,8 @@ player:
     # Load what gamemode a player is in. This is shadow-set to false if
     # 'manage-gamemodes' is true, to stop infinite loop
     gamemode: false
+    # Load the maximum health a player can have
+    max-health: true
     # Load how much health a player has
     health: true
     # Load what level the player is

--- a/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
@@ -9,6 +9,7 @@ import me.gnat008.perworldinventory.commands.ReloadCommand;
 import me.gnat008.perworldinventory.commands.SetWorldDefaultCommand;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
+import me.gnat008.perworldinventory.data.DataSourceProvider;
 import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
@@ -107,6 +108,7 @@ public class PerWorldInventoryInitializationTest {
         injector.register(PluginManager.class, pluginManager);
         injector.provide(DataFolder.class, dataFolder);
         injector.register(Settings.class, settings);
+        injector.registerProvider(DataSource.class, DataSourceProvider.class);
 
         // when
         plugin.injectServices(injector);

--- a/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
@@ -8,8 +8,8 @@ import me.gnat008.perworldinventory.commands.PerWorldInventoryCommand;
 import me.gnat008.perworldinventory.commands.ReloadCommand;
 import me.gnat008.perworldinventory.commands.SetWorldDefaultCommand;
 import me.gnat008.perworldinventory.config.Settings;
-import me.gnat008.perworldinventory.data.DataWriter;
-import me.gnat008.perworldinventory.data.FileWriter;
+import me.gnat008.perworldinventory.data.DataSource;
+import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.player.PlayerGameModeChangeListener;
@@ -41,10 +41,7 @@ import java.util.logging.Logger;
 import static me.gnat008.perworldinventory.TestHelper.getField;
 import static me.gnat008.perworldinventory.TestHelper.setField;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.instanceOf;
-import static org.hamcrest.Matchers.not;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.Matchers.sameInstance;
+import static org.hamcrest.Matchers.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -118,7 +115,7 @@ public class PerWorldInventoryInitializationTest {
 
         // then - check various samples
         assertThat(injector.getIfAvailable(GroupManager.class), not(nullValue()));
-        assertThat(injector.getIfAvailable(DataWriter.class), instanceOf(FileWriter.class));
+        assertThat(injector.getIfAvailable(DataSource.class), instanceOf(FlatFile.class));
         assertThat(injector.getIfAvailable(PWIPlayerManager.class), not(nullValue()));
 
         verifyRegisteredListener(PluginListener.class);

--- a/src/test/java/me/gnat008/perworldinventory/TestHelper.java
+++ b/src/test/java/me/gnat008/perworldinventory/TestHelper.java
@@ -13,7 +13,7 @@ import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.concurrent.TransferQueue;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import static org.mockito.Mockito.mock;
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 public final class TestHelper {
 
     public static final String PROJECT_ROOT = "/me/gnat008/perworldinventory/";
+    public static final UUID TEST_UUID = UUID.randomUUID();
 
     private TestHelper() {
     }
@@ -122,6 +123,8 @@ public final class TestHelper {
     public static Group mockGroup(String name) {
         Set<String> worlds = new HashSet<>();
         worlds.add(name);
+        worlds.add(name + "_nether");
+        worlds.add(name + "_the_end");
 
         return mockGroup(name, worlds);
     }
@@ -136,4 +139,6 @@ public final class TestHelper {
 
         return new Group(name, worldSet, gameMode);
     }
+
+
 }

--- a/src/test/java/me/gnat008/perworldinventory/TestHelper.java
+++ b/src/test/java/me/gnat008/perworldinventory/TestHelper.java
@@ -110,7 +110,7 @@ public final class TestHelper {
 
     public static Logger initMockLogger() {
         Logger logger = mock(Logger.class);
-        PwiLogger.setLogger(logger);
+        ConsoleLogger.setLogger(logger);
         return logger;
     }
 

--- a/src/test/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommandTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/commands/SetWorldDefaultCommandTest.java
@@ -1,10 +1,9 @@
 package me.gnat008.perworldinventory.commands;
 
 import me.gnat008.perworldinventory.PerWorldInventory;
-import me.gnat008.perworldinventory.data.FileWriter;
+import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
-import org.bukkit.GameMode;
 import org.bukkit.World;
 import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
@@ -42,7 +41,7 @@ public class SetWorldDefaultCommandTest {
     private PerWorldInventory plugin;
 
     @Mock
-    private FileWriter fileSerializer;
+    private FlatFile fileSerializer;
 
     @Mock
     private GroupManager groupManager;

--- a/src/test/java/me/gnat008/perworldinventory/data/FlatFileTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/data/FlatFileTest.java
@@ -11,11 +11,7 @@ import me.gnat008.perworldinventory.TestHelper;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;
 import me.gnat008.perworldinventory.groups.Group;
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Location;
-import org.bukkit.Server;
-import org.bukkit.World;
+import org.bukkit.*;
 import org.bukkit.entity.Player;
 import org.junit.Before;
 import org.junit.Rule;
@@ -27,7 +23,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.UUID;
 
 import static me.gnat008.perworldinventory.TestHelper.mockGroup;
@@ -37,15 +32,15 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
 /**
- * Test for {@link FileWriter}
+ * Test for {@link FlatFile}
  */
 @RunWith(MockitoJUnitRunner.class)
-public class FileWriterTest {
+public class FlatFileTest {
 
     private static final UUID UUID_WITH_DATA = UUID.fromString("7f7c909b-24f1-49a4-817f-baa4f4973980");
 
     @InjectDelayed
-    private FileWriter fileWriter;
+    private FlatFile flatFile;
 
     @Mock
     private PerWorldInventory plugin;
@@ -78,7 +73,7 @@ public class FileWriterTest {
         injector.register(PerWorldInventory.class, plugin);
         injector.register(Settings.class, settings);
         injector.register(BukkitService.class, bukkitService);
-        fileWriter = injector.getSingleton(FileWriter.class);
+        flatFile = injector.getSingleton(FlatFile.class);
     }
 
     @Test
@@ -90,7 +85,7 @@ public class FileWriterTest {
         given(player.getUuid()).willReturn(UUID_WITH_DATA);
 
         // when
-        File result = fileWriter.getFile(gameMode, group, player.getUuid());
+        File result = flatFile.getFile(gameMode, group, player.getUuid());
 
         // then
         assertTrue(result.getName().equals("test-group.json"));
@@ -105,7 +100,7 @@ public class FileWriterTest {
         given(player.getUuid()).willReturn(UUID_WITH_DATA);
 
         // when
-        File result = fileWriter.getFile(gameMode, group, player.getUuid());
+        File result = flatFile.getFile(gameMode, group, player.getUuid());
 
         // then
         assertTrue(result.getName().equals("test-group_creative.json"));
@@ -120,7 +115,7 @@ public class FileWriterTest {
         given(player.getUuid()).willReturn(UUID_WITH_DATA);
 
         // when
-        File result = fileWriter.getFile(gameMode, group, player.getUuid());
+        File result = flatFile.getFile(gameMode, group, player.getUuid());
 
         // then
         assertTrue(result.getName().equals("test-group_adventure.json"));
@@ -135,7 +130,7 @@ public class FileWriterTest {
         given(player.getUuid()).willReturn(UUID_WITH_DATA);
 
         // when
-        File result = fileWriter.getFile(gameMode, group, player.getUuid());
+        File result = flatFile.getFile(gameMode, group, player.getUuid());
 
         // then
         assertTrue(result.getName().equals("test-group_creative.json"));
@@ -150,7 +145,7 @@ public class FileWriterTest {
         setUpWorldReturnedByBukkit(world);
 
         // when
-        Location result = fileWriter.getLogoutData(player);
+        Location result = flatFile.getLogoutData(player);
 
         // then
         assertTrue(result != null);
@@ -165,7 +160,7 @@ public class FileWriterTest {
         given(player.getUniqueId()).willReturn(randUUID);
 
         // when
-        Location result = fileWriter.getLogoutData(player);
+        Location result = flatFile.getLogoutData(player);
 
         // then
         assertTrue(result == null);

--- a/src/test/java/me/gnat008/perworldinventory/data/players/PWIPlayerManagerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/data/players/PWIPlayerManagerTest.java
@@ -8,12 +8,14 @@ import me.gnat008.perworldinventory.PerWorldInventory;
 import me.gnat008.perworldinventory.TestHelper;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
-import me.gnat008.perworldinventory.data.DataWriter;
+import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Server;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.Inventory;
 import org.bukkit.inventory.ItemStack;
@@ -22,9 +24,6 @@ import org.bukkit.scheduler.BukkitScheduler;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-
-import java.util.ArrayList;
-import java.util.UUID;
 
 import static me.gnat008.perworldinventory.TestHelper.mockGroup;
 import static org.hamcrest.Matchers.equalTo;
@@ -51,15 +50,13 @@ public class PWIPlayerManagerTest {
     private BukkitService bukkitService;
 
     @Mock
-    private DataWriter dataWriter;
+    private DataSource dataSource;
 
     @Mock
     private GroupManager groupManager;
 
     @Mock
     private Settings settings;
-
-    private static final UUID TEST_UUID = UUID.randomUUID();
 
     @BeforeInjecting
     public void initSettings() {
@@ -80,69 +77,69 @@ public class PWIPlayerManagerTest {
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
 
         // when
-        String result = playerManager.addPlayer(player, group);
+        String result = playerManager.makeKey(player.getUniqueId(), group, GameMode.SURVIVAL);
 
         // then
-        String expected = TEST_UUID.toString() + ".test.survival";
+        String expected = TestHelper.TEST_UUID + ".test.survival";
         assertThat(result, equalTo(expected));
     }
 
     @Test
     public void addPlayerShouldHaveSurvivalKeyNoSeparation() {
         // given
-        Player player = mockPlayer("playah", GameMode.CREATIVE);
+        Player player = mockPlayer("player", GameMode.CREATIVE);
         Group group = mockGroup("test");
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(false);
 
         // when
-        String result = playerManager.addPlayer(player, group);
+        String result = playerManager.makeKey(player.getUniqueId(), group, GameMode.CREATIVE);
 
         // then
-        String expected = TEST_UUID.toString() + ".test.survival";
+        String expected = TestHelper.TEST_UUID + ".test.survival";
         assertThat(result, equalTo(expected));
     }
 
     @Test
     public void addPlayerShouldHaveCreativeKey() {
         // given
-        Player player = mockPlayer("playah", GameMode.CREATIVE);
+        Player player = mockPlayer("Nicole", GameMode.CREATIVE);
         Group group = mockGroup("test");
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
 
         // when
-        String result = playerManager.addPlayer(player, group);
+        String result = playerManager.makeKey(player.getUniqueId(), group, GameMode.CREATIVE);
 
         // then
-        String expected = TEST_UUID.toString() + ".test.creative";
+        String expected = TestHelper.TEST_UUID + ".test.creative";
         assertThat(result, equalTo(expected));
     }
     @Test
     public void addPlayerShouldHaveAdventureKey() {
         // given
-        Player player = mockPlayer("playah", GameMode.ADVENTURE);
+        Player player = mockPlayer("Bob", GameMode.ADVENTURE);
         Group group = mockGroup("test");
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
 
         // when
-        String result = playerManager.addPlayer(player, group);
+        String result = playerManager.makeKey(player.getUniqueId(), group, GameMode.ADVENTURE);
 
         // then
-        String expected = TEST_UUID.toString() + ".test.adventure";
+        String expected = TestHelper.TEST_UUID + ".test.adventure";
         assertThat(result, equalTo(expected));
     }
 
     @Test
     public void addPlayerShouldHaveSpectatorKey() {
         // given
-        Player player = mockPlayer("playah", GameMode.SPECTATOR);
+        Player player = mockPlayer("someDude", GameMode.SPECTATOR);
         Group group = mockGroup("test");
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
 
         // when
-        String result = playerManager.addPlayer(player, group);
+        String result = playerManager.makeKey(player.getUniqueId(), group, GameMode.SPECTATOR);
 
         // then
-        String expected = TEST_UUID.toString() + ".test.spectator";
+        String expected = TestHelper.TEST_UUID + ".test.spectator";
         assertThat(result, equalTo(expected));
     }
 
@@ -158,9 +155,11 @@ public class PWIPlayerManagerTest {
         given(mock.getInventory()).willReturn(inv);
         given(mock.getEnderChest()).willReturn(enderChest);
         given(mock.getName()).willReturn(name);
-        given(mock.getUniqueId()).willReturn(TEST_UUID);
+        given(mock.getUniqueId()).willReturn(TestHelper.TEST_UUID);
         given(mock.getGameMode()).willReturn(gameMode);
-        given(plugin.isEconEnabled()).willReturn(false);
+        AttributeInstance attribute = mock(AttributeInstance.class);
+        given(mock.getAttribute(Attribute.GENERIC_MAX_HEALTH)).willReturn(attribute);
+        given(attribute.getBaseValue()).willReturn(20.0);
 
         return mock;
     }

--- a/src/test/java/me/gnat008/perworldinventory/listeners/PlayerSpawnLocationListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/PlayerSpawnLocationListenerTest.java
@@ -2,7 +2,7 @@ package me.gnat008.perworldinventory.listeners;
 
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
-import me.gnat008.perworldinventory.data.DataWriter;
+import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.player.PlayerSpawnLocationListener;
@@ -40,7 +40,7 @@ public class PlayerSpawnLocationListenerTest {
     private PlayerSpawnLocationListener listener;
 
     @Mock
-    private DataWriter dataWriter;
+    private DataSource dataSource;
 
     @Mock
     private GroupManager groupManager;
@@ -61,7 +61,7 @@ public class PlayerSpawnLocationListenerTest {
         listener.onPlayerSpawn(event);
 
         // then
-        verifyZeroInteractions(dataWriter);
+        verifyZeroInteractions(dataSource);
         verifyZeroInteractions(groupManager);
         verifyZeroInteractions(process);
     }
@@ -75,7 +75,7 @@ public class PlayerSpawnLocationListenerTest {
         Location spawnLocation = new Location(world, 1, 2, 3);
         PlayerSpawnLocationEvent event = new PlayerSpawnLocationEvent(player, spawnLocation);
         given(settings.getProperty(PwiProperties.LOAD_DATA_ON_JOIN)).willReturn(true);
-        given(dataWriter.getLogoutData(player)).willReturn(null);
+        given(dataSource.getLogoutData(player)).willReturn(null);
 
         // when
         listener.onPlayerSpawn(event);
@@ -98,7 +98,7 @@ public class PlayerSpawnLocationListenerTest {
         World oldWorld = mock(World.class);
         given(oldWorld.getName()).willReturn("world");
         Location lastLocation = new Location(oldWorld, 4, 5, 6);
-        given(dataWriter.getLogoutData(player)).willReturn(lastLocation);
+        given(dataSource.getLogoutData(player)).willReturn(lastLocation);
 
         // when
         listener.onPlayerSpawn(event);
@@ -127,7 +127,7 @@ public class PlayerSpawnLocationListenerTest {
         World oldWorld = mock(World.class);
         given(oldWorld.getName()).willReturn("other_world");
         Location lastLocation = new Location(oldWorld, 4, 5, 6);
-        given(dataWriter.getLogoutData(player)).willReturn(lastLocation);
+        given(dataSource.getLogoutData(player)).willReturn(lastLocation);
         Group oldWorldGroup = mockGroup("oldWorldGroup", Collections.singletonList(oldWorld.getName()), GameMode.SURVIVAL);
         given(groupManager.getGroupFromWorld(oldWorld.getName())).willReturn(oldWorldGroup);
 

--- a/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerGameModeChangeListenerTest.java
@@ -1,0 +1,75 @@
+package me.gnat008.perworldinventory.listeners.player;
+
+import me.gnat008.perworldinventory.BukkitService;
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
+import org.bukkit.GameMode;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerGameModeChangeEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static me.gnat008.perworldinventory.TestHelper.mockGroup;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link PlayerGameModeChangeListener}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerGameModeChangeListenerTest {
+
+    @InjectMocks
+    private PlayerGameModeChangeListener listener;
+
+    @Mock
+    private BukkitService bukkitService;
+
+    @Mock
+    private GroupManager groupManager;
+
+    @Mock
+    private PWIPlayerManager playerManager;
+
+    @Test
+    public void shouldDoNothingEventCancelled() {
+        // given
+        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(mock(Player.class), GameMode.CREATIVE);
+        event.setCancelled(true);
+
+        // when
+        listener.onPlayerGameModeChange(event);
+
+        // then
+        verifyZeroInteractions(groupManager);
+        verifyZeroInteractions(playerManager);
+        verifyZeroInteractions(bukkitService);
+    }
+
+    @Test
+    public void shouldDoEverything() {
+        // given
+        Player player = mock(Player.class);
+        World world = mock(World.class);
+        given(world.getName()).willReturn("world");
+        given(player.getWorld()).willReturn(world);
+        Group group = mockGroup("world");
+        given(groupManager.getGroupFromWorld("world")).willReturn(group);
+
+        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, GameMode.CREATIVE);
+
+        // when
+        listener.onPlayerGameModeChange(event);
+
+        // then
+        verify(groupManager).getGroupFromWorld("world");
+        verify(playerManager).addPlayer(player, group);
+        verify(bukkitService).runTaskLater(any(Runnable.class), any(Long.class));
+    }
+}

--- a/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerSpawnLocationListenerTest.java
@@ -1,11 +1,10 @@
-package me.gnat008.perworldinventory.listeners;
+package me.gnat008.perworldinventory.listeners.player;
 
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.groups.Group;
 import me.gnat008.perworldinventory.groups.GroupManager;
-import me.gnat008.perworldinventory.listeners.player.PlayerSpawnLocationListener;
 import me.gnat008.perworldinventory.process.InventoryChangeProcess;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
@@ -25,10 +24,7 @@ import java.util.Set;
 
 import static me.gnat008.perworldinventory.TestHelper.mockGroup;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.only;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link PlayerSpawnLocationListener}.

--- a/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerTeleportListenerTest.java
@@ -1,0 +1,120 @@
+package me.gnat008.perworldinventory.listeners.player;
+
+import me.gnat008.perworldinventory.TestHelper;
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+/**
+ * Tests for {@link PlayerTeleportListener}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerTeleportListenerTest {
+
+    @InjectMocks
+    private PlayerTeleportListener listener;
+
+    @Mock
+    private GroupManager groupManager;
+
+    @Mock
+    private PWIPlayerManager playerManager;
+
+    @Test
+    public void noInteractionsEventCancelled() {
+        // given
+        PlayerTeleportEvent event = mock(PlayerTeleportEvent.class);
+        given(event.isCancelled()).willReturn(true);
+
+        // when
+        listener.onPlayerTeleport(event);
+
+        // then
+        verifyZeroInteractions(groupManager);
+        verifyZeroInteractions(playerManager);
+    }
+
+    @Test
+    public void noInteractionsSameWorld() {
+        // given
+        Player player = mock(Player.class);
+
+        World worldFrom = mock(World.class);
+        Location from = new Location(worldFrom, 1, 2, 3);
+        Location to = new Location(worldFrom, 4, 5, 6);
+
+        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from, to);
+
+        // when
+        listener.onPlayerTeleport(event);
+
+        // then
+        verifyZeroInteractions(groupManager);
+        verifyZeroInteractions(playerManager);
+    }
+
+    @Test
+    public void noPlayerInteractionsSameGroup() {
+        // given
+        Player player = mock(Player.class);
+
+        World worldFrom = mock(World.class);
+        given(worldFrom.getName()).willReturn("world");
+        Location from = new Location(worldFrom, 1, 2, 3);
+        World worldTo = mock(World.class);
+        given(worldTo.getName()).willReturn("world_nether");
+        Location to = new Location(worldTo, 4, 5, 6);
+
+        Group group = TestHelper.mockGroup("world");
+        given(groupManager.getGroupFromWorld("world")).willReturn(group);
+        given(groupManager.getGroupFromWorld("world_nether")).willReturn(group);
+
+        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from, to);
+
+        // when
+        listener.onPlayerTeleport(event);
+
+        // then
+        verifyZeroInteractions(playerManager);
+    }
+
+    @Test
+    public void shouldAddPlayer() {
+        // given
+        Player player = mock(Player.class);
+
+        World worldFrom = mock(World.class);
+        given(worldFrom.getName()).willReturn("world");
+        Location from = new Location(worldFrom, 1, 2, 3);
+        World worldTo = mock(World.class);
+        given(worldTo.getName()).willReturn("world2");
+        Location to = new Location(worldTo, 4, 5, 6);
+
+        Group groupFrom = TestHelper.mockGroup("world");
+        Group groupTo = TestHelper.mockGroup("world2");
+        given(groupManager.getGroupFromWorld("world")).willReturn(groupFrom);
+        given(groupManager.getGroupFromWorld("world2")).willReturn(groupTo);
+
+        PlayerTeleportEvent event = new PlayerTeleportEvent(player, from, to);
+
+        // when
+        listener.onPlayerTeleport(event);
+
+        // then
+        verify(playerManager).addPlayer(player, groupFrom);
+    }
+}

--- a/src/test/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListenerTest.java
@@ -50,4 +50,17 @@ public class InventoryLoadingListenerTest {
         // then
         verifyZeroInteractions(process);
     }
+
+    @Test
+    public void shouldAlsoNotInteract() {
+        // given
+        Player player = mock(Player.class);
+        InventoryLoadCompleteEvent event = new InventoryLoadCompleteEvent(player, DeserializeCause.CHANGED_DEFAULTS);
+
+        // when
+        listener.onLoadComplete(event);
+
+        // then
+        verifyZeroInteractions(process);
+    }
 }

--- a/src/test/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/server/InventoryLoadingListenerTest.java
@@ -1,0 +1,53 @@
+package me.gnat008.perworldinventory.listeners.server;
+
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
+import me.gnat008.perworldinventory.events.InventoryLoadCompleteEvent;
+import me.gnat008.perworldinventory.process.InventoryChangeProcess;
+import org.bukkit.entity.Player;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link InventoryLoadingListener}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class InventoryLoadingListenerTest {
+
+    @InjectMocks
+    private InventoryLoadingListener listener;
+
+    @Mock
+    private InventoryChangeProcess process;
+
+    @Test
+    public void shouldInteract() {
+        // given
+        Player player = mock(Player.class);
+        InventoryLoadCompleteEvent event = new InventoryLoadCompleteEvent(player, DeserializeCause.WORLD_CHANGE);
+
+        // when
+        listener.onLoadComplete(event);
+
+        // then
+        verify(process).postProcessWorldChange(any(Player.class));
+    }
+
+    @Test
+    public void shouldNotInteract() {
+        // given
+        Player player = mock(Player.class);
+        InventoryLoadCompleteEvent event = new InventoryLoadCompleteEvent(player, DeserializeCause.GAMEMODE_CHANGE);
+
+        // when
+        listener.onLoadComplete(event);
+
+        // then
+        verifyZeroInteractions(process);
+    }
+}

--- a/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
@@ -3,14 +3,12 @@ package me.gnat008.perworldinventory.process;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.data.serializers.DeserializeCause;
 import me.gnat008.perworldinventory.groups.Group;
-import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.permission.PermissionManager;
 import me.gnat008.perworldinventory.permission.PlayerPermission;
 import org.bukkit.GameMode;
-import org.bukkit.World;
 import org.bukkit.entity.Player;
-import org.bukkit.event.player.PlayerGameModeChangeEvent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
@@ -32,9 +30,6 @@ public class GameModeChangeProcessTest {
     private GameModeChangeProcess process;
 
     @Mock
-    private GroupManager groupManager;
-
-    @Mock
     private PermissionManager permissionManager;
 
     @Mock
@@ -46,80 +41,56 @@ public class GameModeChangeProcessTest {
     @Test
     public void shouldBypass() {
         // given
-        World world = mock(World.class);
-        given(world.getName()).willReturn("world");
-
         Player player = mock(Player.class);
-        given(player.getWorld()).willReturn(world);
-
-        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, GameMode.ADVENTURE);
 
         Group group = mockGroup("world");
 
-        given(groupManager.getGroupFromWorld("world")).willReturn(group);
         given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(true);
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(false);
 
         // when
-        process.processGameModeChange(event);
+        process.processGameModeChange(player, GameMode.ADVENTURE, group);
 
         // then
-        verify(playerManager).addPlayer(player, group);
-        verify(playerManager, never()).getPlayerData(any(Group.class), any(GameMode.class), any(Player.class));
+        verify(playerManager, never()).getPlayerData(any(Group.class), any(GameMode.class), any(Player.class), any(DeserializeCause.class));
     }
 
     @Test
     public void shouldNotBypassNoPermission() {
         // given
-        World world = mock(World.class);
-        String worldName = "world";
-        given(world.getName()).willReturn(worldName);
-
         Player player = mock(Player.class);
-        given(player.getWorld()).willReturn(world);
 
-        Group group = mockGroup(worldName);
+        Group group = mockGroup("world");
 
         GameMode newGameMode = GameMode.CREATIVE;
-        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
-        given(groupManager.getGroupFromWorld(worldName)).willReturn(group);
         given(permissionManager.hasPermission(player, PlayerPermission.BYPASS_GAMEMODE)).willReturn(false);
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(false);
 
         // when
-        process.processGameModeChange(event);
+        process.processGameModeChange(player, newGameMode, group);
 
         // then
-        verify(playerManager).addPlayer(player, group);
-        verify(playerManager).getPlayerData(group, newGameMode, player);
+        verify(playerManager).getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
     }
 
     @Test
     public void shouldNotBypassBecauseBypassDisabled() {
         // given
-        World world = mock(World.class);
-        String worldName = "world";
-        given(world.getName()).willReturn(worldName);
-
         Player player = mock(Player.class);
-        given(player.getWorld()).willReturn(world);
 
-        Group group = mockGroup(worldName);
+        Group group = mockGroup("world");
 
         GameMode newGameMode = GameMode.CREATIVE;
-        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
-        given(groupManager.getGroupFromWorld(worldName)).willReturn(group);
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(true);
         given(settings.getProperty(PwiProperties.DISABLE_BYPASS)).willReturn(true);
 
         // when
-        process.processGameModeChange(event);
+        process.processGameModeChange(player, newGameMode, group);
 
         // then
-        verify(playerManager).addPlayer(player, group);
-        verify(playerManager).getPlayerData(group, newGameMode, player);
+        verify(playerManager).getPlayerData(group, newGameMode, player, DeserializeCause.GAMEMODE_CHANGE);
     }
 
     @Test
@@ -127,14 +98,13 @@ public class GameModeChangeProcessTest {
         // given
         Player player = mock(Player.class);
         GameMode newGameMode = GameMode.CREATIVE;
-        PlayerGameModeChangeEvent event = new PlayerGameModeChangeEvent(player, newGameMode);
+        Group group = mockGroup("world");
         given(settings.getProperty(PwiProperties.SEPARATE_GAMEMODE_INVENTORIES)).willReturn(false);
 
         // when
-        process.processGameModeChange(event);
+        process.processGameModeChange(player, newGameMode, group);
 
         // then
-        verifyZeroInteractions(groupManager);
         verifyZeroInteractions(permissionManager);
         verifyZeroInteractions(playerManager);
     }

--- a/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/process/GameModeChangeProcessTest.java
@@ -17,15 +17,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.util.*;
-
 import static me.gnat008.perworldinventory.TestHelper.mockGroup;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyZeroInteractions;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
 
 /**
  * Tests for {@link GameModeChangeProcess}.


### PR DESCRIPTION
This should fix cases of inventory bleed across worlds when PerWorldInventories is set to manage gamemodes.

**# Summary:**
- Add event for when an inventory is set to a player
- DataSource and provider backport from the MySQL branch
- Now listen to teleport events and add players to cache when they are called
  - No longer add players to cache after world change has happened