### PR TITLE
Process fix

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -114,10 +114,8 @@ public class PerWorldInventory extends JavaPlugin {
         injector.register(PluginManager.class, getServer().getPluginManager());
         injector.provide(DataFolder.class, getDataFolder());
         injector.registerProvider(DataSource.class, DataSourceProvider.class);
-        settings = initSettings();
-        injector.register(Settings.class, settings);
-        ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
         injectServices(injector);
+        ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
         registerEventListeners(injector);
 
         // Load world groups
@@ -194,6 +192,7 @@ public class PerWorldInventory extends JavaPlugin {
     }
 
     protected void injectServices(Injector injector) {
+        settings = injector.getSingleton(Settings.class);
         groupManager = injector.getSingleton(GroupManager.class);
         playerManager = injector.getSingleton(PWIPlayerManager.class);
         permissionManager = injector.getSingleton(PermissionManager.class);
@@ -300,13 +299,5 @@ public class PerWorldInventory extends JavaPlugin {
         }
 
         return false;
-    }
-
-    private Settings initSettings() {
-        File configFile = new File(getDataFolder(), "config.yml");
-        if (!configFile.exists()) {
-            saveResource("config.yml", false);
-        }
-        return new Settings(configFile);
     }
 }

--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -25,7 +25,6 @@ import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
 import me.gnat008.perworldinventory.data.DataSourceProvider;
-import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
 import me.gnat008.perworldinventory.listeners.entity.EntityPortalEventListener;
@@ -59,9 +58,7 @@ import java.util.*;
 public class PerWorldInventory extends JavaPlugin {
 
     private PerWorldInventoryAPI api;
-    private BukkitService bukkitService;
     private Economy economy;
-    private DataSource serializer;
     private GroupManager groupManager;
     private PWIPlayerManager playerManager;
     private Settings settings;
@@ -116,6 +113,7 @@ public class PerWorldInventory extends JavaPlugin {
         injector.register(Server.class, getServer());
         injector.register(PluginManager.class, getServer().getPluginManager());
         injector.provide(DataFolder.class, getDataFolder());
+        injector.registerProvider(DataSource.class, DataSourceProvider.class);
         settings = initSettings();
         injector.register(Settings.class, settings);
         ConsoleLogger.setUseDebug(settings.getProperty(PwiProperties.DEBUG_MODE));
@@ -196,10 +194,7 @@ public class PerWorldInventory extends JavaPlugin {
     }
 
     protected void injectServices(Injector injector) {
-        bukkitService = injector.getSingleton(BukkitService.class);
         groupManager = injector.getSingleton(GroupManager.class);
-        serializer = injector.getSingleton(FlatFile.class);
-        injector.registerProvider(DataSource.class, DataSourceProvider.class);
         playerManager = injector.getSingleton(PWIPlayerManager.class);
         permissionManager = injector.getSingleton(PermissionManager.class);
         api = injector.getSingleton(PerWorldInventoryAPI.class);

--- a/src/main/java/me/gnat008/perworldinventory/config/Settings.java
+++ b/src/main/java/me/gnat008/perworldinventory/config/Settings.java
@@ -5,6 +5,9 @@ import ch.jalu.configme.migration.PlainMigrationService;
 import ch.jalu.configme.resource.YamlFileResource;
 
 import java.io.File;
+import java.io.IOException;
+
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
 
 /**
  * Settings class for PWI properties.
@@ -16,9 +19,9 @@ public class Settings extends SettingsManager {
      *
      * @param yamlFile the configuration file to load
      */
-    public Settings(File yamlFile) {
+    public Settings(File yamlFile) throws IOException {
         super(
-            new YamlFileResource(yamlFile),
+            new YamlFileResource(createFileIfNotExists(yamlFile)),
             new PlainMigrationService(),
             PwiProperties.class);
     }

--- a/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/DataSourceProvider.java
@@ -5,7 +5,6 @@ import me.gnat008.perworldinventory.ConsoleLogger;
 
 import javax.inject.Inject;
 import javax.inject.Provider;
-import java.io.IOException;
 
 /**
  * Creates the data source
@@ -27,7 +26,7 @@ public class DataSourceProvider implements Provider<DataSource> {
         }
     }
 
-    private DataSource createDataSource() throws ClassNotFoundException, IOException {
+    private DataSource createDataSource() {
         DataSourceType type = DataSourceType.FLATFILE;
         DataSource dataSource;
 

--- a/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/FlatFile.java
@@ -42,6 +42,8 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.UUID;
 
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
+import static me.gnat008.perworldinventory.util.FileUtils.writeData;
 import static me.gnat008.perworldinventory.util.Utils.zeroPlayer;
 
 public class FlatFile implements DataSource {
@@ -76,11 +78,7 @@ public class FlatFile implements DataSource {
 
     private void saveLogout(File file, PWIPlayer player) {
         try {
-            if (!file.getParentFile().exists())
-                file.getParentFile().mkdir();
-            if (!file.exists())
-                file.createNewFile();
-
+            createFileIfNotExists(file);
             String data = LocationSerializer.serialize(player.getLocation());
             writeData(file, data);
         } catch (IOException ex) {
@@ -94,28 +92,13 @@ public class FlatFile implements DataSource {
         ConsoleLogger.debug("Saving data for player '" + player.getName() + "' in file '" + file.getPath() + "'");
 
         try {
-            if (!file.getParentFile().exists()) {
-                file.getParentFile().mkdir();
-            }
-
-            if (!file.exists()) {
-                file.createNewFile();
-            }
-
+            createFileIfNotExists(file);
             ConsoleLogger.debug("Writing player data for player '" + player.getName() + "' to file");
 
             String data = playerSerializer.serialize(player);
             writeData(file, data);
         } catch (IOException ex) {
             ConsoleLogger.severe("Error creating file '" + file + "':", ex);
-        }
-    }
-
-    public void writeData(final File file, final String data) {
-        try (java.io.FileWriter writer = new java.io.FileWriter(file)) {
-            writer.write(data);
-        } catch (IOException ex) {
-            ConsoleLogger.severe("Could not write data to file '" + file + "':", ex);
         }
     }
 
@@ -246,8 +229,7 @@ public class FlatFile implements DataSource {
 
         File tmp = new File(getUserFolder(player.getUniqueId()), "tmp.json");
         try {
-            tmp.getParentFile().mkdirs();
-            tmp.createNewFile();
+            createFileIfNotExists(tmp);
         } catch (IOException ex) {
             player.sendMessage(ChatColor.DARK_RED + "» " + ChatColor.GRAY +  "Could not create temporary file! Aborting!");
             return;

--- a/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/converters/DataConverter.java
@@ -45,6 +45,9 @@ import javax.inject.Inject;
 import java.io.File;
 import java.util.*;
 
+import static me.gnat008.perworldinventory.util.FileUtils.createFileIfNotExists;
+import static me.gnat008.perworldinventory.util.FileUtils.writeData;
+
 @NoMethodScan
 public class DataConverter {
 
@@ -88,11 +91,8 @@ public class DataConverter {
                                 String data = serializeMVIToNewFormat(playerData);
 
                                 File file = serializer.getFile(gameMode, groupManager.getGroup(mvgroup.getName()), player1.getUniqueId());
-                                if (!file.getParentFile().exists())
-                                    file.getParentFile().mkdir();
-                                if (!file.exists())
-                                    file.createNewFile();
-                                serializer.writeData(file, data);
+                                createFileIfNotExists(file);
+                                writeData(file, data);
                             }
                         } catch (Exception ex) {
                             ConsoleLogger.warning("Error importing inventory for player: " + player1.getName() +

--- a/src/main/java/me/gnat008/perworldinventory/util/FileUtils.java
+++ b/src/main/java/me/gnat008/perworldinventory/util/FileUtils.java
@@ -1,11 +1,16 @@
 package me.gnat008.perworldinventory.util;
 
+import me.gnat008.perworldinventory.ConsoleLogger;
+
 import java.io.*;
 
 /**
  * Utility methods for handling files.
  */
-public class FileUtils {
+public final class FileUtils {
+
+    private FileUtils() {
+    }
 
     /**
      * Copy a file from one location to another. The file will not be deleted.
@@ -23,5 +28,43 @@ public class FileUtils {
                 out.write(buff, 0, len);
             }
         }
+    }
+
+    /**
+     * Writes the given data to the provided file.
+     *
+     * @param file The file to write to.
+     * @param data The data to write.
+     */
+    public static void writeData(File file, String data) {
+        try (FileWriter writer = new FileWriter(file)) {
+            writer.write(data);
+        } catch (IOException ex) {
+            ConsoleLogger.severe("Could not write data to file '" + file + "':", ex);
+        }
+    }
+
+    /**
+     * Creates the given file if it doesn't exist.
+     *
+     * @param file The file to create if necessary.
+     * @return The given file (allows inline use).
+     * @throws IOException if file could not be created
+     */
+    public static File createFileIfNotExists(File file) throws IOException {
+        if (!file.exists()) {
+            if (!file.getParentFile().exists()) {
+                boolean success = file.getParentFile().mkdirs();
+                if (!success) {
+                    ConsoleLogger.warning("Could not create parent directories while trying to create '" + file + "'");
+                }
+            }
+
+            boolean success = file.createNewFile();
+            if (!success) {
+                ConsoleLogger.warning("Could not create file '" + file + "'");
+            }
+        }
+        return file;
     }
 }

--- a/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/PerWorldInventoryInitializationTest.java
@@ -9,6 +9,7 @@ import me.gnat008.perworldinventory.commands.ReloadCommand;
 import me.gnat008.perworldinventory.commands.SetWorldDefaultCommand;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.DataSource;
+import me.gnat008.perworldinventory.data.DataSourceProvider;
 import me.gnat008.perworldinventory.data.FlatFile;
 import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
 import me.gnat008.perworldinventory.groups.GroupManager;
@@ -107,6 +108,7 @@ public class PerWorldInventoryInitializationTest {
         injector.register(PluginManager.class, pluginManager);
         injector.provide(DataFolder.class, dataFolder);
         injector.register(Settings.class, settings);
+        injector.registerProvider(DataSource.class, DataSourceProvider.class);
 
         // when
         plugin.injectServices(injector);


### PR DESCRIPTION
Commits are hopefully self-explanatory.

Open points:
- DataConverter still injects `FlatFile` directly. As far as I understand this class converts Multiverse data to the current _data source_, so I'd expect `DataSource` to be the field to be injected here. I know that `FlatFile#getFile` isn't part of the `DataSource` interface, and I don't think it should be: it's an implementation detail of the `FlatFile` class that shouldn't "leak outside." Essentially i believe you're missing a "save" method on your DataSource interface. I didn't do any changes regarding this in case I misunderstood.
- I still think `Utils#zeroPlayer` shouldn't be a static utils method.. ;) Passing the plugin instance to it is a good sign that it is not. But this can be fixed later on; it's not urgent.
- I don't understand the economy stuff. Is the removal of the second account OK for all kinds of setups or should there be some `EconomyManager` class that should encapsulate the economy stuff? (e.g. to make some stuff configurable or to be able to speak to different economy plugins)

Not related to this branch / recent changes:
- bstats initialization should be in its own method, if not even in a separate helper class
- The `catch (FileNotFoundException e)`s that can probably be handled better by checking for file existence beforehand
- I have a patch that tries to unite 9de)serialization logic a little more together... I need to see if I can dig this back up