### PR TITLE
#232 Use latest bStats version as shown on website

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <dependency>
             <groupId>org.bstats</groupId>
             <artifactId>bstats-bukkit</artifactId>
-            <version>LATEST</version>
+            <version>1.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
- Defining version as "latest" provides some 1.2 (non-final?) version that isn't mentioned anywhere on the bStats website and for which there are no examples yet