### PR TITLE
200 death dupe bug

### DIFF
--- a/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
+++ b/src/main/java/me/gnat008/perworldinventory/PerWorldInventory.java
@@ -210,6 +210,7 @@ public class PerWorldInventory extends JavaPlugin {
 
         pluginManager.registerEvents(injector.getSingleton(PlayerTeleportListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerChangedWorldListener.class), this);
+        pluginManager.registerEvents(injector.getSingleton(PlayerDeathListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerGameModeChangeListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(PlayerQuitListener.class), this);
         pluginManager.registerEvents(injector.getSingleton(EntityPortalEventListener.class), this);

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
@@ -88,9 +88,11 @@ public class StatSerializer {
         if (settings.getProperty(PwiProperties.LOAD_HEALTH) && stats.has("health")) {
             double health = stats.get("health").getAsDouble();
             if (health <= player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue()) {
-                player.setHealth(health);
-            } else if (health <= 0) {
-                player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+                if (health <= 0) {
+                    player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
+                } else {
+                    player.setHealth(health);
+                }
             } else {
                 player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
             }

--- a/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
+++ b/src/main/java/me/gnat008/perworldinventory/data/serializers/StatSerializer.java
@@ -18,6 +18,7 @@
 package me.gnat008.perworldinventory.data.serializers;
 
 import com.google.gson.JsonObject;
+import me.gnat008.perworldinventory.ConsoleLogger;
 import me.gnat008.perworldinventory.config.PwiProperties;
 import me.gnat008.perworldinventory.config.Settings;
 import me.gnat008.perworldinventory.data.players.PWIPlayer;

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListener.java
@@ -8,6 +8,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.potion.PotionEffect;
 
 import javax.inject.Inject;
 
@@ -30,6 +31,24 @@ public class PlayerDeathListener implements Listener {
     public void onPlayerDeath(PlayerDeathEvent event) {
         Player player = event.getEntity();
         Group group = groupManager.getGroupFromWorld(player.getLocation().getWorld().getName());
+
+        if (!event.getKeepInventory()) {
+            player.getInventory().clear();
+        }
+
+        if (!event.getKeepLevel()) {
+            player.setExp(event.getNewExp());
+            player.setLevel(event.getNewLevel());
+        }
+
+        player.setFoodLevel(20);
+        player.setSaturation(5f);
+        player.setExhaustion(0f);
+        player.setFallDistance(0f);
+        player.setFireTicks(0);
+        for (PotionEffect effect : player.getActivePotionEffects()) {
+            player.removePotionEffect(effect.getType());
+        }
 
         playerManager.addPlayer(player, group);
     }

--- a/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListener.java
+++ b/src/main/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListener.java
@@ -1,0 +1,36 @@
+package me.gnat008.perworldinventory.listeners.player;
+
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.entity.PlayerDeathEvent;
+
+import javax.inject.Inject;
+
+/**
+ * Listens for any {@link PlayerDeathEvent} in order to prevent
+ * inventory duplication.
+ */
+public class PlayerDeathListener implements Listener {
+
+    private GroupManager groupManager;
+    private PWIPlayerManager playerManager;
+
+    @Inject
+    PlayerDeathListener(GroupManager groupManager, PWIPlayerManager playerManager) {
+        this.groupManager = groupManager;
+        this.playerManager = playerManager;
+    }
+
+    @EventHandler(priority = EventPriority.MONITOR)
+    public void onPlayerDeath(PlayerDeathEvent event) {
+        Player player = event.getEntity();
+        Group group = groupManager.getGroupFromWorld(player.getLocation().getWorld().getName());
+
+        playerManager.addPlayer(player, group);
+    }
+}

--- a/src/main/java/me/gnat008/perworldinventory/util/Utils.java
+++ b/src/main/java/me/gnat008/perworldinventory/util/Utils.java
@@ -68,15 +68,15 @@ public final class Utils {
             player.getEnderChest().clear();
         }
 
-        player.setExp(0.0F);
+        player.setExp(0f);
         player.setFoodLevel(20);
         player.setHealth(player.getAttribute(Attribute.GENERIC_MAX_HEALTH).getValue());
         player.setLevel(0);
         for (PotionEffect effect : player.getActivePotionEffects()) {
             player.removePotionEffect(effect.getType());
         }
-        player.setSaturation(20.0F);
-        player.setFallDistance(0.0f);
+        player.setSaturation(5f);
+        player.setFallDistance(0f);
         player.setFireTicks(0);
 
         if (plugin.isEconEnabled()) {

--- a/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListenerTest.java
+++ b/src/test/java/me/gnat008/perworldinventory/listeners/player/PlayerDeathListenerTest.java
@@ -1,0 +1,148 @@
+package me.gnat008.perworldinventory.listeners.player;
+
+import me.gnat008.perworldinventory.data.players.PWIPlayerManager;
+import me.gnat008.perworldinventory.groups.Group;
+import me.gnat008.perworldinventory.groups.GroupManager;
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.PlayerInventory;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static me.gnat008.perworldinventory.TestHelper.mockGroup;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+/**
+ * Tests for {@link PlayerDeathListener}.
+ */
+@RunWith(MockitoJUnitRunner.class)
+public class PlayerDeathListenerTest {
+
+    @InjectMocks
+    private PlayerDeathListener listener;
+
+    @Mock
+    private GroupManager groupManager;
+
+    @Mock
+    private PWIPlayerManager playerManager;
+
+    @Test
+    public void shouldRemoveInventory() {
+        // given
+        Player player = mock(Player.class);
+        given(player.getInventory()).willReturn(mock(PlayerInventory.class));
+        given(player.getActivePotionEffects()).willReturn(new ArrayList<>());
+        Location loc = mock(Location.class);
+        World world = mock(World.class);
+
+        given(player.getLocation()).willReturn(loc);
+        given(loc.getWorld()).willReturn(world);
+        given(world.getName()).willReturn("test");
+
+        Group group = mockGroup("test");
+        given(groupManager.getGroupFromWorld("test")).willReturn(group);
+
+        List<ItemStack> drops = new ArrayList<>();
+        PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 5, 5, "Bob died.");
+        event.setKeepInventory(false);
+
+        // when
+        listener.onPlayerDeath(event);
+
+        // then
+        verify(player).getInventory();
+    }
+
+    @Test
+    public void shouldNotRemoveInventory() {
+        // given
+        Player player = mock(Player.class);
+        given(player.getActivePotionEffects()).willReturn(new ArrayList<>());
+        Location loc = mock(Location.class);
+        World world = mock(World.class);
+
+        given(player.getLocation()).willReturn(loc);
+        given(loc.getWorld()).willReturn(world);
+        given(world.getName()).willReturn("test");
+
+        Group group = mockGroup("test");
+        given(groupManager.getGroupFromWorld("test")).willReturn(group);
+
+        List<ItemStack> drops = new ArrayList<>();
+        PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 5, 5, "Bob died.");
+        event.setKeepInventory(true);
+
+        // when
+        listener.onPlayerDeath(event);
+
+        // then
+        verify(player, never()).getInventory();
+    }
+
+    @Test
+    public void shouldResetExp() {
+        // given
+        Player player = mock(Player.class);
+        given(player.getInventory()).willReturn(mock(PlayerInventory.class));
+        given(player.getActivePotionEffects()).willReturn(new ArrayList<>());
+        Location loc = mock(Location.class);
+        World world = mock(World.class);
+
+        given(player.getLocation()).willReturn(loc);
+        given(loc.getWorld()).willReturn(world);
+        given(world.getName()).willReturn("test");
+
+        Group group = mockGroup("test");
+        given(groupManager.getGroupFromWorld("test")).willReturn(group);
+
+        List<ItemStack> drops = new ArrayList<>();
+        PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 5, 5, 5, 5, "Bob died.");
+        event.setKeepLevel(false);
+
+        // when
+        listener.onPlayerDeath(event);
+
+        // then
+        verify(player).setExp(5);
+        verify(player).setLevel(5);
+    }
+
+    @Test
+    public void shouldNotResetExp() {
+        // given
+        Player player = mock(Player.class);
+        given(player.getInventory()).willReturn(mock(PlayerInventory.class));
+        given(player.getActivePotionEffects()).willReturn(new ArrayList<>());
+        Location loc = mock(Location.class);
+        World world = mock(World.class);
+
+        given(player.getLocation()).willReturn(loc);
+        given(loc.getWorld()).willReturn(world);
+        given(world.getName()).willReturn("test");
+
+        Group group = mockGroup("test");
+        given(groupManager.getGroupFromWorld("test")).willReturn(group);
+
+        List<ItemStack> drops = new ArrayList<>();
+        PlayerDeathEvent event = new PlayerDeathEvent(player, drops, 5, 5, 5, 5, "Bob died.");
+        event.setKeepLevel(true);
+
+        // when
+        listener.onPlayerDeath(event);
+
+        // then
+        verify(player, never()).setExp(5);
+        verify(player, never()).setLevel(5);
+    }
+}


### PR DESCRIPTION
Ref #200 
This PR adds the handling for player death events, and fixing the inventory dupe bug when players die. Another change here is making how health is applied (checking for health of 0 or less, etc.) consistent between the in-memory cache and the file database code.

The only remaining question is if other player stats have to be "zeroed" on death, but this should be a good start.